### PR TITLE
Update changelog and `mapbox-gl-native` submodule

### DIFF
--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -153,13 +153,13 @@ global.objCTestValue = function (property, layerType, arraysAsStructs, indent) {
         case 'number':
             return '@"1"';
         case 'formatted':
+        case 'resolvedImage':
             // Special 'string' case to handle constant expression text-field that automatically
             // converts Formatted back to string.
             return layerType === 'string' ?
                 `@"'${_.startCase(propertyName)}'"` :
                 `@"${_.startCase(propertyName)}"`;
         case 'string':
-        case 'resolvedImage': // TODO: replace once we implement image expressions
             return `@"'${_.startCase(propertyName)}'"`;
         case 'enum':
             return `@"'${_.last(_.keys(property.values))}'"`;
@@ -296,7 +296,7 @@ global.testHelperMessage = function (property, layerType, isFunction) {
             return 'testNumber' + fnSuffix;
         case 'formatted':
         case 'string':
-        case 'image': // TODO: replace once we implement image expressions
+        case 'resolvedImage':
             return 'testString' + fnSuffix;
         case 'enum':
             let objCType = global.objCType(layerType, property.name);
@@ -526,7 +526,7 @@ global.describeValue = function (value, property, layerType) {
             return 'the float ' + '`' + formatNumber(value) + '`';
         case 'formatted':
         case 'string':
-        case 'image': // TODO: replace once we implement image expressions
+        case 'resolvedImage':
             if (value === '') {
                 return 'the empty string';
             }
@@ -659,8 +659,9 @@ global.valueTransformerArguments = function (property) {
             return ['float', objCType];
         case 'formatted':
             return ['mbgl::style::expression::Formatted', objCType];
+        case 'resolvedImage':
+            return ['mbgl::style::expression::Image', objCType];
         case 'string':
-        case 'resolvedImage': // TODO: replace once we implement image expressions
             return ['std::string', objCType];
         case 'enum':
             return [mbglType(property), 'NSValue *', mbglType(property), `MGL${camelize(property.name)}`];
@@ -699,8 +700,9 @@ global.mbglType = function(property) {
             return 'float';
         case 'formatted':
             return 'mbgl::style::expression::Formatted';
+        case 'resolvedImage':
+            return 'mbgl::style::expression::Image';
         case 'string':
-        case 'resolvedImage': // TODO: replace once we implement image expressions
             return 'std::string';
         case 'enum': {
             let type = camelize(originalPropertyName(property));

--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -159,7 +159,7 @@ global.objCTestValue = function (property, layerType, arraysAsStructs, indent) {
                 `@"'${_.startCase(propertyName)}'"` :
                 `@"${_.startCase(propertyName)}"`;
         case 'string':
-        case 'image': // TODO: replace once we implement image expressions
+        case 'resolvedImage': // TODO: replace once we implement image expressions
             return `@"'${_.startCase(propertyName)}'"`;
         case 'enum':
             return `@"'${_.last(_.keys(property.values))}'"`;
@@ -209,7 +209,7 @@ global.mbglTestValue = function (property, layerType) {
             return '1.0';
         case 'formatted':
         case 'string':
-        case 'image': // TODO: replace once we implement image expressions
+        case 'resolvedImage': // TODO: replace once we implement image expressions
             return `"${_.startCase(propertyName)}"`;
         case 'enum': {
             let type = camelize(originalPropertyName(property));
@@ -477,7 +477,7 @@ global.describeType = function (property) {
             return 'numeric';
         case 'formatted':
         case 'string':
-        case 'image': // TODO: replace once we implement image expressions
+        case 'resolvedImage': // TODO: replace once we implement image expressions
             return 'string';
         case 'enum':
             return '`MGL' + camelize(property.name) + '`';
@@ -613,7 +613,7 @@ global.propertyType = function (property) {
             return 'NSNumber *';
         case 'formatted':
         case 'string':
-        case 'image': // TODO: replace once we implement image expressions
+        case 'resolvedImage': // TODO: replace once we implement image expressions
             return 'NSString *';
         case 'enum':
             return 'NSValue *';
@@ -646,7 +646,7 @@ global.isInterpolatable = function (property) {
     return type !== 'boolean' &&
         type !== 'enum' &&
         type !== 'string' &&
-        type !== 'image' &&
+        type !== 'resolvedImage' &&
         type !== 'formatted';
 };
 
@@ -660,7 +660,7 @@ global.valueTransformerArguments = function (property) {
         case 'formatted':
             return ['mbgl::style::expression::Formatted', objCType];
         case 'string':
-        case 'image': // TODO: replace once we implement image expressions
+        case 'resolvedImage': // TODO: replace once we implement image expressions
             return ['std::string', objCType];
         case 'enum':
             return [mbglType(property), 'NSValue *', mbglType(property), `MGL${camelize(property.name)}`];
@@ -700,7 +700,7 @@ global.mbglType = function(property) {
         case 'formatted':
             return 'mbgl::style::expression::Formatted';
         case 'string':
-        case 'image': // TODO: replace once we implement image expressions
+        case 'resolvedImage': // TODO: replace once we implement image expressions
             return 'std::string';
         case 'enum': {
             let type = camelize(originalPropertyName(property));

--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -153,12 +153,15 @@ global.objCTestValue = function (property, layerType, arraysAsStructs, indent) {
         case 'number':
             return '@"1"';
         case 'formatted':
-        case 'resolvedImage':
             // Special 'string' case to handle constant expression text-field that automatically
             // converts Formatted back to string.
             return layerType === 'string' ?
                 `@"'${_.startCase(propertyName)}'"` :
                 `@"${_.startCase(propertyName)}"`;
+        case 'resolvedImage':
+            return layerType === 'string' ?
+                `@"${_.startCase(propertyName)}"` :
+                `@"MGL_FUNCTION('image', '${_.startCase(propertyName)}')"`;
         case 'string':
             return `@"'${_.startCase(propertyName)}'"`;
         case 'enum':
@@ -209,7 +212,7 @@ global.mbglTestValue = function (property, layerType) {
             return '1.0';
         case 'formatted':
         case 'string':
-        case 'resolvedImage': // TODO: replace once we implement image expressions
+        case 'resolvedImage':
             return `"${_.startCase(propertyName)}"`;
         case 'enum': {
             let type = camelize(originalPropertyName(property));
@@ -477,7 +480,7 @@ global.describeType = function (property) {
             return 'numeric';
         case 'formatted':
         case 'string':
-        case 'resolvedImage': // TODO: replace once we implement image expressions
+        case 'resolvedImage':
             return 'string';
         case 'enum':
             return '`MGL' + camelize(property.name) + '`';
@@ -613,7 +616,7 @@ global.propertyType = function (property) {
             return 'NSNumber *';
         case 'formatted':
         case 'string':
-        case 'resolvedImage': // TODO: replace once we implement image expressions
+        case 'resolvedImage':
             return 'NSString *';
         case 'enum':
             return 'NSValue *';

--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -158,11 +158,8 @@ global.objCTestValue = function (property, layerType, arraysAsStructs, indent) {
             return layerType === 'string' ?
                 `@"'${_.startCase(propertyName)}'"` :
                 `@"${_.startCase(propertyName)}"`;
-        case 'resolvedImage':
-            return layerType === 'string' ?
-                `@"${_.startCase(propertyName)}"` :
-                `@"MGL_FUNCTION('image', '${_.startCase(propertyName)}')"`;
         case 'string':
+        case 'image': // TODO: replace once we implement image expressions
             return `@"'${_.startCase(propertyName)}'"`;
         case 'enum':
             return `@"'${_.last(_.keys(property.values))}'"`;
@@ -212,7 +209,7 @@ global.mbglTestValue = function (property, layerType) {
             return '1.0';
         case 'formatted':
         case 'string':
-        case 'resolvedImage':
+        case 'image': // TODO: replace once we implement image expressions
             return `"${_.startCase(propertyName)}"`;
         case 'enum': {
             let type = camelize(originalPropertyName(property));
@@ -299,7 +296,7 @@ global.testHelperMessage = function (property, layerType, isFunction) {
             return 'testNumber' + fnSuffix;
         case 'formatted':
         case 'string':
-        case 'resolvedImage':
+        case 'image': // TODO: replace once we implement image expressions
             return 'testString' + fnSuffix;
         case 'enum':
             let objCType = global.objCType(layerType, property.name);
@@ -480,7 +477,7 @@ global.describeType = function (property) {
             return 'numeric';
         case 'formatted':
         case 'string':
-        case 'resolvedImage':
+        case 'image': // TODO: replace once we implement image expressions
             return 'string';
         case 'enum':
             return '`MGL' + camelize(property.name) + '`';
@@ -529,7 +526,7 @@ global.describeValue = function (value, property, layerType) {
             return 'the float ' + '`' + formatNumber(value) + '`';
         case 'formatted':
         case 'string':
-        case 'resolvedImage':
+        case 'image': // TODO: replace once we implement image expressions
             if (value === '') {
                 return 'the empty string';
             }
@@ -616,7 +613,7 @@ global.propertyType = function (property) {
             return 'NSNumber *';
         case 'formatted':
         case 'string':
-        case 'resolvedImage':
+        case 'image': // TODO: replace once we implement image expressions
             return 'NSString *';
         case 'enum':
             return 'NSValue *';
@@ -649,7 +646,7 @@ global.isInterpolatable = function (property) {
     return type !== 'boolean' &&
         type !== 'enum' &&
         type !== 'string' &&
-        type !== 'resolvedImage' &&
+        type !== 'image' &&
         type !== 'formatted';
 };
 
@@ -662,9 +659,8 @@ global.valueTransformerArguments = function (property) {
             return ['float', objCType];
         case 'formatted':
             return ['mbgl::style::expression::Formatted', objCType];
-        case 'resolvedImage':
-            return ['mbgl::style::expression::Image', objCType];
         case 'string':
+        case 'image': // TODO: replace once we implement image expressions
             return ['std::string', objCType];
         case 'enum':
             return [mbglType(property), 'NSValue *', mbglType(property), `MGL${camelize(property.name)}`];
@@ -703,9 +699,8 @@ global.mbglType = function(property) {
             return 'float';
         case 'formatted':
             return 'mbgl::style::expression::Formatted';
-        case 'resolvedImage':
-            return 'mbgl::style::expression::Image';
         case 'string':
+        case 'image': // TODO: replace once we implement image expressions
             return 'std::string';
         case 'enum': {
             let type = camelize(originalPropertyName(property));

--- a/platform/darwin/src/MGLAccountManager.h
+++ b/platform/darwin/src/MGLAccountManager.h
@@ -34,7 +34,7 @@ MGL_EXPORT
     and the type `String`. Alternatively, you may call this method from your
     application delegate’s `-applicationDidFinishLaunching:` method.
  */
-@property (class, nullable) NSString *accessToken;
+@property (class, assign, nullable) NSString *accessToken;
 
 @end
 

--- a/platform/darwin/src/MGLAccountManager.h
+++ b/platform/darwin/src/MGLAccountManager.h
@@ -34,7 +34,7 @@ MGL_EXPORT
     and the type `String`. Alternatively, you may call this method from your
     application delegate’s `-applicationDidFinishLaunching:` method.
  */
-@property (class, assign, nullable) NSString *accessToken;
+@property (class, nullable) NSString *accessToken;
 
 @end
 

--- a/platform/darwin/src/MGLBackgroundStyleLayer.mm
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.mm
@@ -106,7 +106,7 @@
     MGLAssertStyleLayerIsValid();
     MGLLogDebug(@"Setting backgroundPattern: %@", backgroundPattern);
 
-    auto mbglValue = MGLStyleValueTransformer<std::string, NSString *>().toPropertyValue<mbgl::style::PropertyValue<std::string>>(backgroundPattern, false);
+    auto mbglValue = MGLStyleValueTransformer<mbgl::style::expression::Image, NSString *>().toPropertyValue<mbgl::style::PropertyValue<mbgl::style::expression::Image>>(backgroundPattern, false);
     self.rawLayer->setBackgroundPattern(mbglValue);
 }
 
@@ -117,7 +117,7 @@
     if (propertyValue.isUndefined()) {
         propertyValue = self.rawLayer->getDefaultBackgroundPattern();
     }
-    return MGLStyleValueTransformer<std::string, NSString *>().toExpression(propertyValue);
+    return MGLStyleValueTransformer<mbgl::style::expression::Image, NSString *>().toExpression(propertyValue);
 }
 
 - (void)setBackgroundPatternTransition:(MGLTransition )transition {

--- a/platform/darwin/src/MGLBackgroundStyleLayer.mm
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.mm
@@ -106,7 +106,7 @@
     MGLAssertStyleLayerIsValid();
     MGLLogDebug(@"Setting backgroundPattern: %@", backgroundPattern);
 
-    auto mbglValue = MGLStyleValueTransformer<mbgl::style::expression::Image, NSString *>().toPropertyValue<mbgl::style::PropertyValue<mbgl::style::expression::Image>>(backgroundPattern, false);
+    auto mbglValue = MGLStyleValueTransformer<std::string, NSString *>().toPropertyValue<mbgl::style::PropertyValue<std::string>>(backgroundPattern, false);
     self.rawLayer->setBackgroundPattern(mbglValue);
 }
 
@@ -117,7 +117,7 @@
     if (propertyValue.isUndefined()) {
         propertyValue = self.rawLayer->getDefaultBackgroundPattern();
     }
-    return MGLStyleValueTransformer<mbgl::style::expression::Image, NSString *>().toExpression(propertyValue);
+    return MGLStyleValueTransformer<std::string, NSString *>().toExpression(propertyValue);
 }
 
 - (void)setBackgroundPatternTransition:(MGLTransition )transition {

--- a/platform/darwin/src/MGLConversion.h
+++ b/platform/darwin/src/MGLConversion.h
@@ -124,7 +124,7 @@ public:
         }
     }
 
-    static optional<GeoJSON> toGeoJSON(const Holder& holder, Error& error) {
+    static optional<GeoJSON> toGeoJSON(const Holder&, Error& error) {
         error = { "toGeoJSON not implemented" };
         return {};
     }

--- a/platform/darwin/src/MGLFillExtrusionStyleLayer.mm
+++ b/platform/darwin/src/MGLFillExtrusionStyleLayer.mm
@@ -244,7 +244,7 @@ namespace mbgl {
     MGLAssertStyleLayerIsValid();
     MGLLogDebug(@"Setting fillExtrusionPattern: %@", fillExtrusionPattern);
 
-    auto mbglValue = MGLStyleValueTransformer<std::string, NSString *>().toPropertyValue<mbgl::style::PropertyValue<std::string>>(fillExtrusionPattern, true);
+    auto mbglValue = MGLStyleValueTransformer<mbgl::style::expression::Image, NSString *>().toPropertyValue<mbgl::style::PropertyValue<mbgl::style::expression::Image>>(fillExtrusionPattern, true);
     self.rawLayer->setFillExtrusionPattern(mbglValue);
 }
 
@@ -255,7 +255,7 @@ namespace mbgl {
     if (propertyValue.isUndefined()) {
         propertyValue = self.rawLayer->getDefaultFillExtrusionPattern();
     }
-    return MGLStyleValueTransformer<std::string, NSString *>().toExpression(propertyValue);
+    return MGLStyleValueTransformer<mbgl::style::expression::Image, NSString *>().toExpression(propertyValue);
 }
 
 - (void)setFillExtrusionPatternTransition:(MGLTransition )transition {

--- a/platform/darwin/src/MGLFillExtrusionStyleLayer.mm
+++ b/platform/darwin/src/MGLFillExtrusionStyleLayer.mm
@@ -244,7 +244,7 @@ namespace mbgl {
     MGLAssertStyleLayerIsValid();
     MGLLogDebug(@"Setting fillExtrusionPattern: %@", fillExtrusionPattern);
 
-    auto mbglValue = MGLStyleValueTransformer<mbgl::style::expression::Image, NSString *>().toPropertyValue<mbgl::style::PropertyValue<mbgl::style::expression::Image>>(fillExtrusionPattern, true);
+    auto mbglValue = MGLStyleValueTransformer<std::string, NSString *>().toPropertyValue<mbgl::style::PropertyValue<std::string>>(fillExtrusionPattern, true);
     self.rawLayer->setFillExtrusionPattern(mbglValue);
 }
 
@@ -255,7 +255,7 @@ namespace mbgl {
     if (propertyValue.isUndefined()) {
         propertyValue = self.rawLayer->getDefaultFillExtrusionPattern();
     }
-    return MGLStyleValueTransformer<mbgl::style::expression::Image, NSString *>().toExpression(propertyValue);
+    return MGLStyleValueTransformer<std::string, NSString *>().toExpression(propertyValue);
 }
 
 - (void)setFillExtrusionPatternTransition:(MGLTransition )transition {

--- a/platform/darwin/src/MGLFillStyleLayer.mm
+++ b/platform/darwin/src/MGLFillStyleLayer.mm
@@ -211,7 +211,7 @@ namespace mbgl {
     MGLAssertStyleLayerIsValid();
     MGLLogDebug(@"Setting fillPattern: %@", fillPattern);
 
-    auto mbglValue = MGLStyleValueTransformer<std::string, NSString *>().toPropertyValue<mbgl::style::PropertyValue<std::string>>(fillPattern, true);
+    auto mbglValue = MGLStyleValueTransformer<mbgl::style::expression::Image, NSString *>().toPropertyValue<mbgl::style::PropertyValue<mbgl::style::expression::Image>>(fillPattern, true);
     self.rawLayer->setFillPattern(mbglValue);
 }
 
@@ -222,7 +222,7 @@ namespace mbgl {
     if (propertyValue.isUndefined()) {
         propertyValue = self.rawLayer->getDefaultFillPattern();
     }
-    return MGLStyleValueTransformer<std::string, NSString *>().toExpression(propertyValue);
+    return MGLStyleValueTransformer<mbgl::style::expression::Image, NSString *>().toExpression(propertyValue);
 }
 
 - (void)setFillPatternTransition:(MGLTransition )transition {

--- a/platform/darwin/src/MGLFillStyleLayer.mm
+++ b/platform/darwin/src/MGLFillStyleLayer.mm
@@ -211,7 +211,7 @@ namespace mbgl {
     MGLAssertStyleLayerIsValid();
     MGLLogDebug(@"Setting fillPattern: %@", fillPattern);
 
-    auto mbglValue = MGLStyleValueTransformer<mbgl::style::expression::Image, NSString *>().toPropertyValue<mbgl::style::PropertyValue<mbgl::style::expression::Image>>(fillPattern, true);
+    auto mbglValue = MGLStyleValueTransformer<std::string, NSString *>().toPropertyValue<mbgl::style::PropertyValue<std::string>>(fillPattern, true);
     self.rawLayer->setFillPattern(mbglValue);
 }
 
@@ -222,7 +222,7 @@ namespace mbgl {
     if (propertyValue.isUndefined()) {
         propertyValue = self.rawLayer->getDefaultFillPattern();
     }
-    return MGLStyleValueTransformer<mbgl::style::expression::Image, NSString *>().toExpression(propertyValue);
+    return MGLStyleValueTransformer<std::string, NSString *>().toExpression(propertyValue);
 }
 
 - (void)setFillPatternTransition:(MGLTransition )transition {

--- a/platform/darwin/src/MGLLineStyleLayer.mm
+++ b/platform/darwin/src/MGLLineStyleLayer.mm
@@ -396,7 +396,7 @@ namespace mbgl {
     MGLAssertStyleLayerIsValid();
     MGLLogDebug(@"Setting linePattern: %@", linePattern);
 
-    auto mbglValue = MGLStyleValueTransformer<std::string, NSString *>().toPropertyValue<mbgl::style::PropertyValue<std::string>>(linePattern, true);
+    auto mbglValue = MGLStyleValueTransformer<mbgl::style::expression::Image, NSString *>().toPropertyValue<mbgl::style::PropertyValue<mbgl::style::expression::Image>>(linePattern, true);
     self.rawLayer->setLinePattern(mbglValue);
 }
 
@@ -407,7 +407,7 @@ namespace mbgl {
     if (propertyValue.isUndefined()) {
         propertyValue = self.rawLayer->getDefaultLinePattern();
     }
-    return MGLStyleValueTransformer<std::string, NSString *>().toExpression(propertyValue);
+    return MGLStyleValueTransformer<mbgl::style::expression::Image, NSString *>().toExpression(propertyValue);
 }
 
 - (void)setLinePatternTransition:(MGLTransition )transition {

--- a/platform/darwin/src/MGLLineStyleLayer.mm
+++ b/platform/darwin/src/MGLLineStyleLayer.mm
@@ -396,7 +396,7 @@ namespace mbgl {
     MGLAssertStyleLayerIsValid();
     MGLLogDebug(@"Setting linePattern: %@", linePattern);
 
-    auto mbglValue = MGLStyleValueTransformer<mbgl::style::expression::Image, NSString *>().toPropertyValue<mbgl::style::PropertyValue<mbgl::style::expression::Image>>(linePattern, true);
+    auto mbglValue = MGLStyleValueTransformer<std::string, NSString *>().toPropertyValue<mbgl::style::PropertyValue<std::string>>(linePattern, true);
     self.rawLayer->setLinePattern(mbglValue);
 }
 
@@ -407,7 +407,7 @@ namespace mbgl {
     if (propertyValue.isUndefined()) {
         propertyValue = self.rawLayer->getDefaultLinePattern();
     }
-    return MGLStyleValueTransformer<mbgl::style::expression::Image, NSString *>().toExpression(propertyValue);
+    return MGLStyleValueTransformer<std::string, NSString *>().toExpression(propertyValue);
 }
 
 - (void)setLinePatternTransition:(MGLTransition )transition {

--- a/platform/darwin/src/MGLStyleLayer.mm.ejs
+++ b/platform/darwin/src/MGLStyleLayer.mm.ejs
@@ -136,6 +136,9 @@ namespace mbgl {
 <% if (property.type === 'formatted') { -%>
             self.rawLayer->set<%- camelize(originalPropertyName(property)) %>(mbgl::style::PropertyValue<mbgl::style::expression::Formatted>(
                 mbgl::style::conversion::convertTokenStringToFormatExpression(string)));
+<% } else if (property.type === 'resolvedImage') { -%>
+            self.rawLayer->set<%- camelize(originalPropertyName(property)) %>(mbgl::style::PropertyValue<mbgl::style::expression::Image>(
+                mbgl::style::conversion::convertTokenStringToImageExpression(string)));
 <% } else { -%>
             self.rawLayer->set<%- camelize(originalPropertyName(property)) %>(mbgl::style::PropertyValue<std::string>(
                 mbgl::style::conversion::convertTokenStringToExpression(string)));

--- a/platform/darwin/src/MGLStyleValue_Private.h
+++ b/platform/darwin/src/MGLStyleValue_Private.h
@@ -217,6 +217,11 @@ private: // Private utilities for converting from mgl to mbgl values
         mbglValue = rawValue.mgl_color;
     }
 
+    // Image
+    void getMBGLValue(NSString *rawValue, mbgl::style::expression::Image &mbglValue) {
+        mbglValue = mbgl::style::expression::Image(rawValue.UTF8String);
+    }
+
     // Array
     void getMBGLValue(ObjCType rawValue, std::vector<MBGLElement> &mbglValue) {
         mbglValue.reserve(rawValue.count);
@@ -293,6 +298,11 @@ private: // Private utilities for converting from mbgl to mgl values
     // Color
     static MGLColor *toMGLRawStyleValue(const mbgl::Color mbglStopValue) {
         return [MGLColor mgl_colorWithColor:mbglStopValue];
+    }
+
+    // Image
+    static NSString *toMGLRawStyleValue(const mbgl::style::expression::Image &mbglImageValue) {
+        return @(mbglImageValue.id().c_str());
     }
 
     // Array

--- a/platform/darwin/src/MGLStyleValue_Private.h
+++ b/platform/darwin/src/MGLStyleValue_Private.h
@@ -140,7 +140,7 @@ private: // Private utilities for converting from mgl to mbgl values
     class = typename std::enable_if<!std::is_enum<MBGLEnum>::value>::type,
     typename MGLEnum = ObjCEnum,
     class = typename std::enable_if<!std::is_enum<MGLEnum>::value>::type>
-    NSObject* toRawStyleSpecValue(NSObject *rawMGLValue, MBGLEnum &mbglValue) {
+    NSObject* toRawStyleSpecValue(NSObject *rawMGLValue, MBGLEnum &) {
         if ([rawMGLValue isKindOfClass:[NSValue class]]) {
             const auto rawNSValue = (NSValue *)rawMGLValue;
             if (strcmp([rawNSValue objCType], @encode(CGVector)) == 0) {
@@ -157,13 +157,13 @@ private: // Private utilities for converting from mgl to mbgl values
     class = typename std::enable_if<std::is_enum<MBGLEnum>::value>::type,
     typename MGLEnum = ObjCEnum,
     class = typename std::enable_if<std::is_enum<MGLEnum>::value>::type>
-    NSString* toRawStyleSpecValue(ObjCType rawValue, MBGLEnum &mbglValue) {
+    NSString* toRawStyleSpecValue(ObjCType rawValue, MBGLEnum &) {
         MGLEnum mglEnum;
         [rawValue getValue:&mglEnum];
         return @(mbgl::Enum<MGLEnum>::toString(mglEnum));
     }
 
-    NSObject* toRawStyleSpecValue(MGLColor *color, MBGLType &mbglValue) {
+    NSObject* toRawStyleSpecValue(MGLColor *color, MBGLType &) {
         return @(color.mgl_color.stringify().c_str());
     }
 

--- a/platform/darwin/src/MGLSymbolStyleLayer.mm
+++ b/platform/darwin/src/MGLSymbolStyleLayer.mm
@@ -248,12 +248,12 @@ namespace mbgl {
     if (iconImageName && iconImageName.expressionType == NSConstantValueExpressionType) {
         std::string string = ((NSString *)iconImageName.constantValue).UTF8String;
         if (mbgl::style::conversion::hasTokens(string)) {
-            self.rawLayer->setIconImage(mbgl::style::PropertyValue<std::string>(
-                mbgl::style::conversion::convertTokenStringToExpression(string)));
+            self.rawLayer->setIconImage(mbgl::style::PropertyValue<mbgl::style::expression::Image>(
+                mbgl::style::conversion::convertTokenStringToImageExpression(string)));
             return;
         }
     }
-    auto mbglValue = MGLStyleValueTransformer<std::string, NSString *>().toPropertyValue<mbgl::style::PropertyValue<std::string>>(iconImageName, true);
+    auto mbglValue = MGLStyleValueTransformer<mbgl::style::expression::Image, NSString *>().toPropertyValue<mbgl::style::PropertyValue<mbgl::style::expression::Image>>(iconImageName, true);
     self.rawLayer->setIconImage(mbglValue);
 }
 
@@ -264,7 +264,7 @@ namespace mbgl {
     if (propertyValue.isUndefined()) {
         propertyValue = self.rawLayer->getDefaultIconImage();
     }
-    return MGLStyleValueTransformer<std::string, NSString *>().toExpression(propertyValue);
+    return MGLStyleValueTransformer<mbgl::style::expression::Image, NSString *>().toExpression(propertyValue);
 }
 
 - (void)setIconImage:(NSExpression *)iconImage {

--- a/platform/darwin/src/MGLSymbolStyleLayer.mm
+++ b/platform/darwin/src/MGLSymbolStyleLayer.mm
@@ -248,12 +248,12 @@ namespace mbgl {
     if (iconImageName && iconImageName.expressionType == NSConstantValueExpressionType) {
         std::string string = ((NSString *)iconImageName.constantValue).UTF8String;
         if (mbgl::style::conversion::hasTokens(string)) {
-            self.rawLayer->setIconImage(mbgl::style::PropertyValue<mbgl::style::expression::Image>(
-                mbgl::style::conversion::convertTokenStringToImageExpression(string)));
+            self.rawLayer->setIconImage(mbgl::style::PropertyValue<std::string>(
+                mbgl::style::conversion::convertTokenStringToExpression(string)));
             return;
         }
     }
-    auto mbglValue = MGLStyleValueTransformer<mbgl::style::expression::Image, NSString *>().toPropertyValue<mbgl::style::PropertyValue<mbgl::style::expression::Image>>(iconImageName, true);
+    auto mbglValue = MGLStyleValueTransformer<std::string, NSString *>().toPropertyValue<mbgl::style::PropertyValue<std::string>>(iconImageName, true);
     self.rawLayer->setIconImage(mbglValue);
 }
 
@@ -264,7 +264,7 @@ namespace mbgl {
     if (propertyValue.isUndefined()) {
         propertyValue = self.rawLayer->getDefaultIconImage();
     }
-    return MGLStyleValueTransformer<mbgl::style::expression::Image, NSString *>().toExpression(propertyValue);
+    return MGLStyleValueTransformer<std::string, NSString *>().toExpression(propertyValue);
 }
 
 - (void)setIconImage:(NSExpression *)iconImage {

--- a/platform/darwin/src/NSExpression+MGLAdditions.mm
+++ b/platform/darwin/src/NSExpression+MGLAdditions.mm
@@ -1229,6 +1229,7 @@ NSArray *MGLSubexpressionsWithJSONObjects(NSArray *objects) {
                     
                     return expressionObject;
                 }
+
                 return self.arguments.mgl_jsonExpressionObject;
             } else if (op == [MGLColor class] && [function isEqualToString:@"colorWithRed:green:blue:alpha:"]) {
                 NSArray *arguments = self.arguments.mgl_jsonExpressionObject;

--- a/platform/darwin/src/http_file_source.mm
+++ b/platform/darwin/src/http_file_source.mm
@@ -196,13 +196,20 @@ HTTPFileSource::HTTPFileSource()
 HTTPFileSource::~HTTPFileSource() = default;
 
 MGL_EXPORT
+BOOL isValidMapboxEndpoint(NSURL *url) {
+    return ([url.host isEqualToString:@"mapbox.com"] ||
+            [url.host hasSuffix:@".mapbox.com"] ||
+            [url.host isEqualToString:@"mapbox.cn"] ||
+            [url.host hasSuffix:@".mapbox.cn"]);
+}
+
+MGL_EXPORT
 NSURL *resourceURLWithAccountType(const Resource& resource, NSInteger accountType) {
     
     NSURL *url = [NSURL URLWithString:@(resource.url.c_str())];
     
 #if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
-    if (accountType == 0 &&
-        ([url.host isEqualToString:@"mapbox.com"] || [url.host hasSuffix:@".mapbox.com"])) {
+    if (accountType == 0 && isValidMapboxEndpoint(url)) {
         NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
         NSMutableArray *queryItems = [NSMutableArray array];
 

--- a/platform/darwin/test/MGLBackgroundStyleLayerTests.mm
+++ b/platform/darwin/test/MGLBackgroundStyleLayerTests.mm
@@ -140,7 +140,7 @@
                       @"background-pattern should be unset initially.");
         NSExpression *defaultExpression = layer.backgroundPattern;
 
-        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"Background Pattern"];
+        NSExpression *constantExpression = [NSExpression expressionForConstantValue:@"Background Pattern"];
         layer.backgroundPattern = constantExpression;
         mbgl::style::PropertyValue<mbgl::style::expression::Image> propertyValue = { "Background Pattern" };
         XCTAssertEqual(rawLayer->getBackgroundPattern(), propertyValue,
@@ -148,14 +148,14 @@
         XCTAssertEqualObjects(layer.backgroundPattern, constantExpression,
                               @"backgroundPattern should round-trip constant value expressions.");
 
-        constantExpression = [NSExpression expressionWithFormat:@"Background Pattern"];
+        constantExpression = [NSExpression expressionWithFormat:@"MGL_FUNCTION('image', 'Background Pattern')"];
         NSExpression *functionExpression = [NSExpression expressionWithFormat:@"mgl_step:from:stops:($zoomLevel, %@, %@)", constantExpression, @{@18: constantExpression}];
         layer.backgroundPattern = functionExpression;
 
         {
             using namespace mbgl::style::expression::dsl;
             propertyValue = mbgl::style::PropertyExpression<mbgl::style::expression::Image>(
-                step(zoom(), literal("Background Pattern"), 18.0, literal("Background Pattern"))
+                step(zoom(), image(literal("Background Pattern")), 18.0, image(literal("Background Pattern")))
             );
         }
 

--- a/platform/darwin/test/MGLBackgroundStyleLayerTests.mm
+++ b/platform/darwin/test/MGLBackgroundStyleLayerTests.mm
@@ -140,21 +140,21 @@
                       @"background-pattern should be unset initially.");
         NSExpression *defaultExpression = layer.backgroundPattern;
 
-        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"'Background Pattern'"];
+        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"Background Pattern"];
         layer.backgroundPattern = constantExpression;
-        mbgl::style::PropertyValue<std::string> propertyValue = { "Background Pattern" };
+        mbgl::style::PropertyValue<mbgl::style::expression::Image> propertyValue = { "Background Pattern" };
         XCTAssertEqual(rawLayer->getBackgroundPattern(), propertyValue,
                        @"Setting backgroundPattern to a constant value expression should update background-pattern.");
         XCTAssertEqualObjects(layer.backgroundPattern, constantExpression,
                               @"backgroundPattern should round-trip constant value expressions.");
 
-        constantExpression = [NSExpression expressionWithFormat:@"'Background Pattern'"];
+        constantExpression = [NSExpression expressionWithFormat:@"Background Pattern"];
         NSExpression *functionExpression = [NSExpression expressionWithFormat:@"mgl_step:from:stops:($zoomLevel, %@, %@)", constantExpression, @{@18: constantExpression}];
         layer.backgroundPattern = functionExpression;
 
         {
             using namespace mbgl::style::expression::dsl;
-            propertyValue = mbgl::style::PropertyExpression<std::string>(
+            propertyValue = mbgl::style::PropertyExpression<mbgl::style::expression::Image>(
                 step(zoom(), literal("Background Pattern"), 18.0, literal("Background Pattern"))
             );
         }

--- a/platform/darwin/test/MGLBackgroundStyleLayerTests.mm
+++ b/platform/darwin/test/MGLBackgroundStyleLayerTests.mm
@@ -140,22 +140,22 @@
                       @"background-pattern should be unset initially.");
         NSExpression *defaultExpression = layer.backgroundPattern;
 
-        NSExpression *constantExpression = [NSExpression expressionForConstantValue:@"Background Pattern"];
+        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"'Background Pattern'"];
         layer.backgroundPattern = constantExpression;
-        mbgl::style::PropertyValue<mbgl::style::expression::Image> propertyValue = { "Background Pattern" };
+        mbgl::style::PropertyValue<std::string> propertyValue = { "Background Pattern" };
         XCTAssertEqual(rawLayer->getBackgroundPattern(), propertyValue,
                        @"Setting backgroundPattern to a constant value expression should update background-pattern.");
         XCTAssertEqualObjects(layer.backgroundPattern, constantExpression,
                               @"backgroundPattern should round-trip constant value expressions.");
 
-        constantExpression = [NSExpression expressionWithFormat:@"MGL_FUNCTION('image', 'Background Pattern')"];
+        constantExpression = [NSExpression expressionWithFormat:@"'Background Pattern'"];
         NSExpression *functionExpression = [NSExpression expressionWithFormat:@"mgl_step:from:stops:($zoomLevel, %@, %@)", constantExpression, @{@18: constantExpression}];
         layer.backgroundPattern = functionExpression;
 
         {
             using namespace mbgl::style::expression::dsl;
-            propertyValue = mbgl::style::PropertyExpression<mbgl::style::expression::Image>(
-                step(zoom(), image(literal("Background Pattern")), 18.0, image(literal("Background Pattern")))
+            propertyValue = mbgl::style::PropertyExpression<std::string>(
+                step(zoom(), literal("Background Pattern"), 18.0, literal("Background Pattern"))
             );
         }
 

--- a/platform/darwin/test/MGLFillExtrusionStyleLayerTests.mm
+++ b/platform/darwin/test/MGLFillExtrusionStyleLayerTests.mm
@@ -386,21 +386,21 @@
                       @"fill-extrusion-pattern should be unset initially.");
         NSExpression *defaultExpression = layer.fillExtrusionPattern;
 
-        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"'Fill Extrusion Pattern'"];
+        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"Fill Extrusion Pattern"];
         layer.fillExtrusionPattern = constantExpression;
-        mbgl::style::PropertyValue<std::string> propertyValue = { "Fill Extrusion Pattern" };
+        mbgl::style::PropertyValue<mbgl::style::expression::Image> propertyValue = { "Fill Extrusion Pattern" };
         XCTAssertEqual(rawLayer->getFillExtrusionPattern(), propertyValue,
                        @"Setting fillExtrusionPattern to a constant value expression should update fill-extrusion-pattern.");
         XCTAssertEqualObjects(layer.fillExtrusionPattern, constantExpression,
                               @"fillExtrusionPattern should round-trip constant value expressions.");
 
-        constantExpression = [NSExpression expressionWithFormat:@"'Fill Extrusion Pattern'"];
+        constantExpression = [NSExpression expressionWithFormat:@"Fill Extrusion Pattern"];
         NSExpression *functionExpression = [NSExpression expressionWithFormat:@"mgl_step:from:stops:($zoomLevel, %@, %@)", constantExpression, @{@18: constantExpression}];
         layer.fillExtrusionPattern = functionExpression;
 
         {
             using namespace mbgl::style::expression::dsl;
-            propertyValue = mbgl::style::PropertyExpression<std::string>(
+            propertyValue = mbgl::style::PropertyExpression<mbgl::style::expression::Image>(
                 step(zoom(), literal("Fill Extrusion Pattern"), 18.0, literal("Fill Extrusion Pattern"))
             );
         }

--- a/platform/darwin/test/MGLFillExtrusionStyleLayerTests.mm
+++ b/platform/darwin/test/MGLFillExtrusionStyleLayerTests.mm
@@ -386,7 +386,7 @@
                       @"fill-extrusion-pattern should be unset initially.");
         NSExpression *defaultExpression = layer.fillExtrusionPattern;
 
-        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"Fill Extrusion Pattern"];
+        NSExpression *constantExpression = [NSExpression expressionForConstantValue:@"Fill Extrusion Pattern"];
         layer.fillExtrusionPattern = constantExpression;
         mbgl::style::PropertyValue<mbgl::style::expression::Image> propertyValue = { "Fill Extrusion Pattern" };
         XCTAssertEqual(rawLayer->getFillExtrusionPattern(), propertyValue,
@@ -394,14 +394,14 @@
         XCTAssertEqualObjects(layer.fillExtrusionPattern, constantExpression,
                               @"fillExtrusionPattern should round-trip constant value expressions.");
 
-        constantExpression = [NSExpression expressionWithFormat:@"Fill Extrusion Pattern"];
+        constantExpression = [NSExpression expressionWithFormat:@"MGL_FUNCTION('image', 'Fill Extrusion Pattern')"];
         NSExpression *functionExpression = [NSExpression expressionWithFormat:@"mgl_step:from:stops:($zoomLevel, %@, %@)", constantExpression, @{@18: constantExpression}];
         layer.fillExtrusionPattern = functionExpression;
 
         {
             using namespace mbgl::style::expression::dsl;
             propertyValue = mbgl::style::PropertyExpression<mbgl::style::expression::Image>(
-                step(zoom(), literal("Fill Extrusion Pattern"), 18.0, literal("Fill Extrusion Pattern"))
+                step(zoom(), image(literal("Fill Extrusion Pattern")), 18.0, image(literal("Fill Extrusion Pattern")))
             );
         }
 

--- a/platform/darwin/test/MGLFillExtrusionStyleLayerTests.mm
+++ b/platform/darwin/test/MGLFillExtrusionStyleLayerTests.mm
@@ -386,22 +386,22 @@
                       @"fill-extrusion-pattern should be unset initially.");
         NSExpression *defaultExpression = layer.fillExtrusionPattern;
 
-        NSExpression *constantExpression = [NSExpression expressionForConstantValue:@"Fill Extrusion Pattern"];
+        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"'Fill Extrusion Pattern'"];
         layer.fillExtrusionPattern = constantExpression;
-        mbgl::style::PropertyValue<mbgl::style::expression::Image> propertyValue = { "Fill Extrusion Pattern" };
+        mbgl::style::PropertyValue<std::string> propertyValue = { "Fill Extrusion Pattern" };
         XCTAssertEqual(rawLayer->getFillExtrusionPattern(), propertyValue,
                        @"Setting fillExtrusionPattern to a constant value expression should update fill-extrusion-pattern.");
         XCTAssertEqualObjects(layer.fillExtrusionPattern, constantExpression,
                               @"fillExtrusionPattern should round-trip constant value expressions.");
 
-        constantExpression = [NSExpression expressionWithFormat:@"MGL_FUNCTION('image', 'Fill Extrusion Pattern')"];
+        constantExpression = [NSExpression expressionWithFormat:@"'Fill Extrusion Pattern'"];
         NSExpression *functionExpression = [NSExpression expressionWithFormat:@"mgl_step:from:stops:($zoomLevel, %@, %@)", constantExpression, @{@18: constantExpression}];
         layer.fillExtrusionPattern = functionExpression;
 
         {
             using namespace mbgl::style::expression::dsl;
-            propertyValue = mbgl::style::PropertyExpression<mbgl::style::expression::Image>(
-                step(zoom(), image(literal("Fill Extrusion Pattern")), 18.0, image(literal("Fill Extrusion Pattern")))
+            propertyValue = mbgl::style::PropertyExpression<std::string>(
+                step(zoom(), literal("Fill Extrusion Pattern"), 18.0, literal("Fill Extrusion Pattern"))
             );
         }
 

--- a/platform/darwin/test/MGLFillStyleLayerTests.mm
+++ b/platform/darwin/test/MGLFillStyleLayerTests.mm
@@ -333,21 +333,21 @@
                       @"fill-pattern should be unset initially.");
         NSExpression *defaultExpression = layer.fillPattern;
 
-        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"'Fill Pattern'"];
+        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"Fill Pattern"];
         layer.fillPattern = constantExpression;
-        mbgl::style::PropertyValue<std::string> propertyValue = { "Fill Pattern" };
+        mbgl::style::PropertyValue<mbgl::style::expression::Image> propertyValue = { "Fill Pattern" };
         XCTAssertEqual(rawLayer->getFillPattern(), propertyValue,
                        @"Setting fillPattern to a constant value expression should update fill-pattern.");
         XCTAssertEqualObjects(layer.fillPattern, constantExpression,
                               @"fillPattern should round-trip constant value expressions.");
 
-        constantExpression = [NSExpression expressionWithFormat:@"'Fill Pattern'"];
+        constantExpression = [NSExpression expressionWithFormat:@"Fill Pattern"];
         NSExpression *functionExpression = [NSExpression expressionWithFormat:@"mgl_step:from:stops:($zoomLevel, %@, %@)", constantExpression, @{@18: constantExpression}];
         layer.fillPattern = functionExpression;
 
         {
             using namespace mbgl::style::expression::dsl;
-            propertyValue = mbgl::style::PropertyExpression<std::string>(
+            propertyValue = mbgl::style::PropertyExpression<mbgl::style::expression::Image>(
                 step(zoom(), literal("Fill Pattern"), 18.0, literal("Fill Pattern"))
             );
         }

--- a/platform/darwin/test/MGLFillStyleLayerTests.mm
+++ b/platform/darwin/test/MGLFillStyleLayerTests.mm
@@ -333,7 +333,7 @@
                       @"fill-pattern should be unset initially.");
         NSExpression *defaultExpression = layer.fillPattern;
 
-        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"Fill Pattern"];
+        NSExpression *constantExpression = [NSExpression expressionForConstantValue:@"Fill Pattern"];
         layer.fillPattern = constantExpression;
         mbgl::style::PropertyValue<mbgl::style::expression::Image> propertyValue = { "Fill Pattern" };
         XCTAssertEqual(rawLayer->getFillPattern(), propertyValue,
@@ -341,14 +341,14 @@
         XCTAssertEqualObjects(layer.fillPattern, constantExpression,
                               @"fillPattern should round-trip constant value expressions.");
 
-        constantExpression = [NSExpression expressionWithFormat:@"Fill Pattern"];
+        constantExpression = [NSExpression expressionWithFormat:@"MGL_FUNCTION('image', 'Fill Pattern')"];
         NSExpression *functionExpression = [NSExpression expressionWithFormat:@"mgl_step:from:stops:($zoomLevel, %@, %@)", constantExpression, @{@18: constantExpression}];
         layer.fillPattern = functionExpression;
 
         {
             using namespace mbgl::style::expression::dsl;
             propertyValue = mbgl::style::PropertyExpression<mbgl::style::expression::Image>(
-                step(zoom(), literal("Fill Pattern"), 18.0, literal("Fill Pattern"))
+                step(zoom(), image(literal("Fill Pattern")), 18.0, image(literal("Fill Pattern")))
             );
         }
 

--- a/platform/darwin/test/MGLFillStyleLayerTests.mm
+++ b/platform/darwin/test/MGLFillStyleLayerTests.mm
@@ -333,22 +333,22 @@
                       @"fill-pattern should be unset initially.");
         NSExpression *defaultExpression = layer.fillPattern;
 
-        NSExpression *constantExpression = [NSExpression expressionForConstantValue:@"Fill Pattern"];
+        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"'Fill Pattern'"];
         layer.fillPattern = constantExpression;
-        mbgl::style::PropertyValue<mbgl::style::expression::Image> propertyValue = { "Fill Pattern" };
+        mbgl::style::PropertyValue<std::string> propertyValue = { "Fill Pattern" };
         XCTAssertEqual(rawLayer->getFillPattern(), propertyValue,
                        @"Setting fillPattern to a constant value expression should update fill-pattern.");
         XCTAssertEqualObjects(layer.fillPattern, constantExpression,
                               @"fillPattern should round-trip constant value expressions.");
 
-        constantExpression = [NSExpression expressionWithFormat:@"MGL_FUNCTION('image', 'Fill Pattern')"];
+        constantExpression = [NSExpression expressionWithFormat:@"'Fill Pattern'"];
         NSExpression *functionExpression = [NSExpression expressionWithFormat:@"mgl_step:from:stops:($zoomLevel, %@, %@)", constantExpression, @{@18: constantExpression}];
         layer.fillPattern = functionExpression;
 
         {
             using namespace mbgl::style::expression::dsl;
-            propertyValue = mbgl::style::PropertyExpression<mbgl::style::expression::Image>(
-                step(zoom(), image(literal("Fill Pattern")), 18.0, image(literal("Fill Pattern")))
+            propertyValue = mbgl::style::PropertyExpression<std::string>(
+                step(zoom(), literal("Fill Pattern"), 18.0, literal("Fill Pattern"))
             );
         }
 

--- a/platform/darwin/test/MGLLineStyleLayerTests.mm
+++ b/platform/darwin/test/MGLLineStyleLayerTests.mm
@@ -659,7 +659,7 @@
                       @"line-pattern should be unset initially.");
         NSExpression *defaultExpression = layer.linePattern;
 
-        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"Line Pattern"];
+        NSExpression *constantExpression = [NSExpression expressionForConstantValue:@"Line Pattern"];
         layer.linePattern = constantExpression;
         mbgl::style::PropertyValue<mbgl::style::expression::Image> propertyValue = { "Line Pattern" };
         XCTAssertEqual(rawLayer->getLinePattern(), propertyValue,
@@ -667,14 +667,14 @@
         XCTAssertEqualObjects(layer.linePattern, constantExpression,
                               @"linePattern should round-trip constant value expressions.");
 
-        constantExpression = [NSExpression expressionWithFormat:@"Line Pattern"];
+        constantExpression = [NSExpression expressionWithFormat:@"MGL_FUNCTION('image', 'Line Pattern')"];
         NSExpression *functionExpression = [NSExpression expressionWithFormat:@"mgl_step:from:stops:($zoomLevel, %@, %@)", constantExpression, @{@18: constantExpression}];
         layer.linePattern = functionExpression;
 
         {
             using namespace mbgl::style::expression::dsl;
             propertyValue = mbgl::style::PropertyExpression<mbgl::style::expression::Image>(
-                step(zoom(), literal("Line Pattern"), 18.0, literal("Line Pattern"))
+                step(zoom(), image(literal("Line Pattern")), 18.0, image(literal("Line Pattern")))
             );
         }
 

--- a/platform/darwin/test/MGLLineStyleLayerTests.mm
+++ b/platform/darwin/test/MGLLineStyleLayerTests.mm
@@ -659,21 +659,21 @@
                       @"line-pattern should be unset initially.");
         NSExpression *defaultExpression = layer.linePattern;
 
-        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"'Line Pattern'"];
+        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"Line Pattern"];
         layer.linePattern = constantExpression;
-        mbgl::style::PropertyValue<std::string> propertyValue = { "Line Pattern" };
+        mbgl::style::PropertyValue<mbgl::style::expression::Image> propertyValue = { "Line Pattern" };
         XCTAssertEqual(rawLayer->getLinePattern(), propertyValue,
                        @"Setting linePattern to a constant value expression should update line-pattern.");
         XCTAssertEqualObjects(layer.linePattern, constantExpression,
                               @"linePattern should round-trip constant value expressions.");
 
-        constantExpression = [NSExpression expressionWithFormat:@"'Line Pattern'"];
+        constantExpression = [NSExpression expressionWithFormat:@"Line Pattern"];
         NSExpression *functionExpression = [NSExpression expressionWithFormat:@"mgl_step:from:stops:($zoomLevel, %@, %@)", constantExpression, @{@18: constantExpression}];
         layer.linePattern = functionExpression;
 
         {
             using namespace mbgl::style::expression::dsl;
-            propertyValue = mbgl::style::PropertyExpression<std::string>(
+            propertyValue = mbgl::style::PropertyExpression<mbgl::style::expression::Image>(
                 step(zoom(), literal("Line Pattern"), 18.0, literal("Line Pattern"))
             );
         }

--- a/platform/darwin/test/MGLLineStyleLayerTests.mm
+++ b/platform/darwin/test/MGLLineStyleLayerTests.mm
@@ -659,22 +659,22 @@
                       @"line-pattern should be unset initially.");
         NSExpression *defaultExpression = layer.linePattern;
 
-        NSExpression *constantExpression = [NSExpression expressionForConstantValue:@"Line Pattern"];
+        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"'Line Pattern'"];
         layer.linePattern = constantExpression;
-        mbgl::style::PropertyValue<mbgl::style::expression::Image> propertyValue = { "Line Pattern" };
+        mbgl::style::PropertyValue<std::string> propertyValue = { "Line Pattern" };
         XCTAssertEqual(rawLayer->getLinePattern(), propertyValue,
                        @"Setting linePattern to a constant value expression should update line-pattern.");
         XCTAssertEqualObjects(layer.linePattern, constantExpression,
                               @"linePattern should round-trip constant value expressions.");
 
-        constantExpression = [NSExpression expressionWithFormat:@"MGL_FUNCTION('image', 'Line Pattern')"];
+        constantExpression = [NSExpression expressionWithFormat:@"'Line Pattern'"];
         NSExpression *functionExpression = [NSExpression expressionWithFormat:@"mgl_step:from:stops:($zoomLevel, %@, %@)", constantExpression, @{@18: constantExpression}];
         layer.linePattern = functionExpression;
 
         {
             using namespace mbgl::style::expression::dsl;
-            propertyValue = mbgl::style::PropertyExpression<mbgl::style::expression::Image>(
-                step(zoom(), image(literal("Line Pattern")), 18.0, image(literal("Line Pattern")))
+            propertyValue = mbgl::style::PropertyExpression<std::string>(
+                step(zoom(), literal("Line Pattern"), 18.0, literal("Line Pattern"))
             );
         }
 

--- a/platform/darwin/test/MGLStyleLayerTests.mm.ejs
+++ b/platform/darwin/test/MGLStyleLayerTests.mm.ejs
@@ -73,6 +73,8 @@
 
 <% if (property.type === 'formatted') { -%>
         NSExpression *constantExpression = [NSExpression expressionWithFormat:<%- objCTestValue(property, 'string', true, 3) %>];
+<% } else if (property.type === 'resolvedImage'){ -%>
+        NSExpression *constantExpression = [NSExpression expressionForConstantValue:<%- objCTestValue(property, 'string', true, 3) %>];
 <% } else { -%>
         NSExpression *constantExpression = [NSExpression expressionWithFormat:<%- objCTestValue(property, type, true, 3) %>];
 <% } -%>
@@ -98,6 +100,8 @@
             propertyValue = mbgl::style::PropertyExpression<<%- mbglType(property) %>>(
 <% if (property.type === 'formatted') { -%>
                 step(zoom(), format(<%- mbglExpressionTestValue(property, type) %>), 18.0, format(<%- mbglExpressionTestValue(property, type) %>))
+<% } else if (property.type === 'resolvedImage') { -%>
+                step(zoom(), image(literal(<%- mbglExpressionTestValue(property, type) %>)), 18.0, image(literal(<%- mbglExpressionTestValue(property, type) %>)))
 <% } else { -%>
                 step(zoom(), literal(<%- mbglExpressionTestValue(property, type) %>), 18.0, literal(<%- mbglExpressionTestValue(property, type) %>))
 <% } -%>
@@ -179,6 +183,8 @@
             propertyValue = mbgl::style::PropertyExpression<<%- mbglType(property) %>>(
 <% if (property.type === 'formatted') { -%>
                 format(toString(get(literal("token"))))
+<% } else if (property.type === 'resolvedImage') { -%>
+                image(toString(get(literal("token"))))
 <% } else { -%>
                 toString(get(literal("token")))
 <% } -%>
@@ -192,6 +198,8 @@
         MGLAttributedExpression *tokenAttibutedExpression = [[MGLAttributedExpression alloc] initWithExpression:[NSExpression expressionWithFormat:@"CAST(token, 'NSString')"]
                                                                                                      attributes:@{}];
         NSExpression* tokenExpression = [NSExpression mgl_expressionForAttributedExpressions:@[[NSExpression expressionForConstantValue:tokenAttibutedExpression]]];
+<% } else if (property.type === 'resolvedImage') { -%>
+        NSExpression* tokenExpression = [NSExpression expressionWithFormat:@"MGL_FUNCTION('image', CAST(token, \"NSString\"))"];
 <% } else { -%>
         NSExpression* tokenExpression = [NSExpression expressionWithFormat:@"CAST(token, \"NSString\")"];
 <% } -%>

--- a/platform/darwin/test/MGLSymbolStyleLayerTests.mm
+++ b/platform/darwin/test/MGLSymbolStyleLayerTests.mm
@@ -182,21 +182,21 @@
                       @"icon-image should be unset initially.");
         NSExpression *defaultExpression = layer.iconImageName;
 
-        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"'Icon Image'"];
+        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"Icon Image"];
         layer.iconImageName = constantExpression;
-        mbgl::style::PropertyValue<std::string> propertyValue = { "Icon Image" };
+        mbgl::style::PropertyValue<mbgl::style::expression::Image> propertyValue = { "Icon Image" };
         XCTAssertEqual(rawLayer->getIconImage(), propertyValue,
                        @"Setting iconImageName to a constant value expression should update icon-image.");
         XCTAssertEqualObjects(layer.iconImageName, constantExpression,
                               @"iconImageName should round-trip constant value expressions.");
 
-        constantExpression = [NSExpression expressionWithFormat:@"'Icon Image'"];
+        constantExpression = [NSExpression expressionWithFormat:@"Icon Image"];
         NSExpression *functionExpression = [NSExpression expressionWithFormat:@"mgl_step:from:stops:($zoomLevel, %@, %@)", constantExpression, @{@18: constantExpression}];
         layer.iconImageName = functionExpression;
 
         {
             using namespace mbgl::style::expression::dsl;
-            propertyValue = mbgl::style::PropertyExpression<std::string>(
+            propertyValue = mbgl::style::PropertyExpression<mbgl::style::expression::Image>(
                 step(zoom(), literal("Icon Image"), 18.0, literal("Icon Image"))
             );
         }
@@ -218,7 +218,7 @@
 
         {
             using namespace mbgl::style::expression::dsl;
-            propertyValue = mbgl::style::PropertyExpression<std::string>(
+            propertyValue = mbgl::style::PropertyExpression<mbgl::style::expression::Image>(
                 toString(get(literal("token")))
             );
         }

--- a/platform/darwin/test/MGLSymbolStyleLayerTests.mm
+++ b/platform/darwin/test/MGLSymbolStyleLayerTests.mm
@@ -182,7 +182,7 @@
                       @"icon-image should be unset initially.");
         NSExpression *defaultExpression = layer.iconImageName;
 
-        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"Icon Image"];
+        NSExpression *constantExpression = [NSExpression expressionForConstantValue:@"Icon Image"];
         layer.iconImageName = constantExpression;
         mbgl::style::PropertyValue<mbgl::style::expression::Image> propertyValue = { "Icon Image" };
         XCTAssertEqual(rawLayer->getIconImage(), propertyValue,
@@ -190,14 +190,14 @@
         XCTAssertEqualObjects(layer.iconImageName, constantExpression,
                               @"iconImageName should round-trip constant value expressions.");
 
-        constantExpression = [NSExpression expressionWithFormat:@"Icon Image"];
+        constantExpression = [NSExpression expressionWithFormat:@"MGL_FUNCTION('image', 'Icon Image')"];
         NSExpression *functionExpression = [NSExpression expressionWithFormat:@"mgl_step:from:stops:($zoomLevel, %@, %@)", constantExpression, @{@18: constantExpression}];
         layer.iconImageName = functionExpression;
 
         {
             using namespace mbgl::style::expression::dsl;
             propertyValue = mbgl::style::PropertyExpression<mbgl::style::expression::Image>(
-                step(zoom(), literal("Icon Image"), 18.0, literal("Icon Image"))
+                step(zoom(), image(literal("Icon Image")), 18.0, image(literal("Icon Image")))
             );
         }
 
@@ -219,14 +219,14 @@
         {
             using namespace mbgl::style::expression::dsl;
             propertyValue = mbgl::style::PropertyExpression<mbgl::style::expression::Image>(
-                toString(get(literal("token")))
+                image(toString(get(literal("token"))))
             );
         }
 
         XCTAssertEqual(rawLayer->getIconImage(), propertyValue,
                        @"Setting iconImageName to a constant string with tokens should convert to an expression.");
 
-        NSExpression* tokenExpression = [NSExpression expressionWithFormat:@"CAST(token, \"NSString\")"];
+        NSExpression* tokenExpression = [NSExpression expressionWithFormat:@"MGL_FUNCTION('image', CAST(token, \"NSString\"))"];
         XCTAssertEqualObjects(layer.iconImageName, tokenExpression,
                               @"Setting iconImageName to a constant string with tokens should convert to an expression.");
     }

--- a/platform/darwin/test/MGLSymbolStyleLayerTests.mm
+++ b/platform/darwin/test/MGLSymbolStyleLayerTests.mm
@@ -182,22 +182,22 @@
                       @"icon-image should be unset initially.");
         NSExpression *defaultExpression = layer.iconImageName;
 
-        NSExpression *constantExpression = [NSExpression expressionForConstantValue:@"Icon Image"];
+        NSExpression *constantExpression = [NSExpression expressionWithFormat:@"'Icon Image'"];
         layer.iconImageName = constantExpression;
-        mbgl::style::PropertyValue<mbgl::style::expression::Image> propertyValue = { "Icon Image" };
+        mbgl::style::PropertyValue<std::string> propertyValue = { "Icon Image" };
         XCTAssertEqual(rawLayer->getIconImage(), propertyValue,
                        @"Setting iconImageName to a constant value expression should update icon-image.");
         XCTAssertEqualObjects(layer.iconImageName, constantExpression,
                               @"iconImageName should round-trip constant value expressions.");
 
-        constantExpression = [NSExpression expressionWithFormat:@"MGL_FUNCTION('image', 'Icon Image')"];
+        constantExpression = [NSExpression expressionWithFormat:@"'Icon Image'"];
         NSExpression *functionExpression = [NSExpression expressionWithFormat:@"mgl_step:from:stops:($zoomLevel, %@, %@)", constantExpression, @{@18: constantExpression}];
         layer.iconImageName = functionExpression;
 
         {
             using namespace mbgl::style::expression::dsl;
-            propertyValue = mbgl::style::PropertyExpression<mbgl::style::expression::Image>(
-                step(zoom(), image(literal("Icon Image")), 18.0, image(literal("Icon Image")))
+            propertyValue = mbgl::style::PropertyExpression<std::string>(
+                step(zoom(), literal("Icon Image"), 18.0, literal("Icon Image"))
             );
         }
 
@@ -218,15 +218,15 @@
 
         {
             using namespace mbgl::style::expression::dsl;
-            propertyValue = mbgl::style::PropertyExpression<mbgl::style::expression::Image>(
-                image(toString(get(literal("token"))))
+            propertyValue = mbgl::style::PropertyExpression<std::string>(
+                toString(get(literal("token")))
             );
         }
 
         XCTAssertEqual(rawLayer->getIconImage(), propertyValue,
                        @"Setting iconImageName to a constant string with tokens should convert to an expression.");
 
-        NSExpression* tokenExpression = [NSExpression expressionWithFormat:@"MGL_FUNCTION('image', CAST(token, \"NSString\"))"];
+        NSExpression* tokenExpression = [NSExpression expressionWithFormat:@"CAST(token, \"NSString\")"];
         XCTAssertEqualObjects(layer.iconImageName, tokenExpression,
                               @"Setting iconImageName to a constant string with tokens should convert to an expression.");
     }

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -3,6 +3,7 @@
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
 ## master
+* Added support for [image expression](https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-types-image) in core library. Runtime APIs for image expression will be implemented separately. ([#15877](https://github.com/mapbox/mapbox-gl-native/pull/15877))
 
 ### Other changes
 * Convert GeoJSON features to tiles for the loaded source description in a background thread and thus unblock the UI thread ([#15885](https://github.com/mapbox/mapbox-gl-native/pull/15885))

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ## master
 * Added support for [image expression](https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-types-image) in core library. Runtime APIs for image expression will be implemented separately. ([#15877](https://github.com/mapbox/mapbox-gl-native/pull/15877))
+* Make network requests for expired resources lower priority than requests for new resources. ([#15950](https://github.com/mapbox/mapbox-gl-native/pull/15950))
 
 ### Other changes
 * Convert GeoJSON features to tiles for the loaded source description in a background thread and thus unblock the UI thread ([#15885](https://github.com/mapbox/mapbox-gl-native/pull/15885))

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,6 +4,11 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ## master
 
+### Other changes
+* Convert GeoJSON features to tiles for the loaded source description in a background thread and thus unblock the UI thread ([#15885](https://github.com/mapbox/mapbox-gl-native/pull/15885))
+
+### Bug fixes
+* Fixed the rendering bug caused by redundant pending requests for already requested images [#15864](https://github.com/mapbox/mapbox-gl-native/pull/15864)
 * Fix ornaments' view constraints bug when devices change to bold-text mode. ([#57](https://github.com/mapbox/mapbox-gl-native-ios/pull/57))
 
 ## 5.5.0 - November 5, 2019

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -12,6 +12,8 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed the rendering bug caused by redundant pending requests for already requested images [#15864](https://github.com/mapbox/mapbox-gl-native/pull/15864)
 * Enable incremental vacuum for the offline database in order to make data removal requests faster and to avoid the excessive disk space usage (creating a backup file on VACUUM call). ([#15837](https://github.com/mapbox/mapbox-gl-native/pull/15837))
 * Fix ornaments' view constraints bug when devices change to bold-text mode. ([#57](https://github.com/mapbox/mapbox-gl-native-ios/pull/57))
+* Fixed Geo JSON source flickering on style transition. ([#15907](https://github.com/mapbox/mapbox-gl-native/pull/15907))
+* Fixed flickering caused by unnecessary removing and re-adding of the render sources when the order of their corresponding style objects was changed in the updated style ([#15941](https://github.com/mapbox/mapbox-gl-native/pull/15941))
 
 ## 5.5.0 - November 5, 2019
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -3,18 +3,20 @@
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
 ## master
-* Added support for [image expression](https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-types-image) in core library. Runtime APIs for image expression will be implemented separately. ([#15877](https://github.com/mapbox/mapbox-gl-native/pull/15877))
-* Make network requests for expired resources lower priority than requests for new resources. ([#15950](https://github.com/mapbox/mapbox-gl-native/pull/15950))
 
-### Other changes
-* Convert GeoJSON features to tiles for the loaded source description in a background thread and thus unblock the UI thread ([#15885](https://github.com/mapbox/mapbox-gl-native/pull/15885))
+### Networking and storage
+* Make network requests for expired resources lower priority than requests for new resources. ([#15950](https://github.com/mapbox/mapbox-gl-native/pull/15950))
 
 ### Bug fixes
 * Fixed the rendering bug caused by redundant pending requests for already requested images [#15864](https://github.com/mapbox/mapbox-gl-native/pull/15864)
 * Enable incremental vacuum for the offline database in order to make data removal requests faster and to avoid the excessive disk space usage (creating a backup file on VACUUM call). ([#15837](https://github.com/mapbox/mapbox-gl-native/pull/15837))
 * Fix ornaments' view constraints bug when devices change to bold-text mode. ([#57](https://github.com/mapbox/mapbox-gl-native-ios/pull/57))
-* Fixed Geo JSON source flickering on style transition. ([#15907](https://github.com/mapbox/mapbox-gl-native/pull/15907))
+* Fixed `MGLShapeSource` source flickering on style transition. ([#15907](https://github.com/mapbox/mapbox-gl-native/pull/15907))
 * Fixed flickering caused by unnecessary removing and re-adding of the render sources when the order of their corresponding style objects was changed in the updated style ([#15941](https://github.com/mapbox/mapbox-gl-native/pull/15941))
+
+### Other changes
+* Convert GeoJSON features to tiles for the loaded source description in a background thread and thus unblock the UI thread ([#15885](https://github.com/mapbox/mapbox-gl-native/pull/15885))
+* 
 
 ## 5.5.0 - November 5, 2019
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ### Bug fixes
 * Fixed the rendering bug caused by redundant pending requests for already requested images [#15864](https://github.com/mapbox/mapbox-gl-native/pull/15864)
+* Enable incremental vacuum for the offline database in order to make data removal requests faster and to avoid the excessive disk space usage (creating a backup file on VACUUM call). ([#15837](https://github.com/mapbox/mapbox-gl-native/pull/15837))
 * Fix ornaments' view constraints bug when devices change to bold-text mode. ([#57](https://github.com/mapbox/mapbox-gl-native-ios/pull/57))
 
 ## 5.5.0 - November 5, 2019

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -696,8 +696,6 @@
 		DAA4E4341CBB730400178DFB /* MGLFaux3DUserLocationAnnotationView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA88484E1CBAFB9800AB86E3 /* MGLFaux3DUserLocationAnnotationView.m */; };
 		DAA4E4351CBB730400178DFB /* SMCalloutView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA88488A1CBB037E00AB86E3 /* SMCalloutView.m */; };
 		DAAE5F8720F046E60089D85B /* libmbgl-core.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DAABF73B1CBC59BB005B1825 /* libmbgl-core.a */; };
-		DAAE5F8920F047240089D85B /* libmbgl-filesource.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 55D120A91F79100C004B6D81 /* libmbgl-filesource.a */; };
-		DAAE5F8A20F0472E0089D85B /* libmbgl-loop-darwin.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 55D120A71F791007004B6D81 /* libmbgl-loop-darwin.a */; };
 		DAAF722B1DA903C700312FA4 /* MGLStyleValue.h in Headers */ = {isa = PBXBuildFile; fileRef = DAAF72291DA903C700312FA4 /* MGLStyleValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DAAF722C1DA903C700312FA4 /* MGLStyleValue.h in Headers */ = {isa = PBXBuildFile; fileRef = DAAF72291DA903C700312FA4 /* MGLStyleValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DAAF722D1DA903C700312FA4 /* MGLStyleValue_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DAAF722A1DA903C700312FA4 /* MGLStyleValue_Private.h */; };
@@ -1530,9 +1528,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				358B3DBB2359EA0F007BEB26 /* libmbgl-vendor-icu.a in Frameworks */,
+				35BEB5002359BB9600110752 /* libmbgl-core.a in Frameworks */,
 				358B3DB92359E4A0007BEB26 /* libsqlite3.tbd in Frameworks */,
 				96802766226556C5006BA4A1 /* libmbxaccounts.a in Frameworks */,
-				35BEB5002359BB9600110752 /* libmbgl-core.a in Frameworks */,
 				DA27C24E1CBB3811000B0ECD /* GLKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1541,11 +1539,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				55CF7531213ED92A00ED86C4 /* libmbgl-vendor-icu.a in Frameworks */,
 				DAAE5F8720F046E60089D85B /* libmbgl-core.a in Frameworks */,
 				9680276422655696006BA4A1 /* libmbxaccounts.a in Frameworks */,
-				DAAE5F8920F047240089D85B /* libmbgl-filesource.a in Frameworks */,
-				DAAE5F8A20F0472E0089D85B /* libmbgl-loop-darwin.a in Frameworks */,
-				55CF7531213ED92A00ED86C4 /* libmbgl-vendor-icu.a in Frameworks */,
 				550570D22296E96E00228ECF /* GLKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4086,8 +4082,8 @@
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/typewrapper/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/weak/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/rapidjson/include",
+					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/expected-lite/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/polylabel/include",
-					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/expected/include",
 					"$(PROJECT_DIR)/../../platform/darwin/include",
 				);
 				INFOPLIST_FILE = framework/Info.plist;
@@ -4137,8 +4133,8 @@
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/typewrapper/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/weak/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/rapidjson/include",
+					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/expected-lite/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/polylabel/include",
-					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/expected/include",
 					"$(PROJECT_DIR)/../../platform/darwin/include",
 				);
 				LIBRARY_SEARCH_PATHS = (
@@ -4562,8 +4558,8 @@
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/typewrapper/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/weak/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/rapidjson/include",
+					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/expected-lite/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/polylabel/include",
-					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/expected/include",
 					"$(PROJECT_DIR)/../../platform/darwin/include",
 				);
 				INFOPLIST_FILE = framework/Info.plist;
@@ -4620,8 +4616,8 @@
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/typewrapper/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/weak/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/rapidjson/include",
+					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/expected-lite/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/polylabel/include",
-					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/expected/include",
 					"$(PROJECT_DIR)/../../platform/darwin/include",
 				);
 				INFOPLIST_FILE = framework/Info.plist;
@@ -4694,8 +4690,8 @@
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/typewrapper/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/weak/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/rapidjson/include",
+					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/expected-lite/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/polylabel/include",
-					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/expected/include",
 					"$(PROJECT_DIR)/../../platform/darwin/include",
 				);
 				LIBRARY_SEARCH_PATHS = (
@@ -4742,8 +4738,8 @@
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/typewrapper/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/weak/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/rapidjson/include",
+					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/expected-lite/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/polylabel/include",
-					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/expected/include",
 					"$(PROJECT_DIR)/../../platform/darwin/include",
 				);
 				LIBRARY_SEARCH_PATHS = (

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -3839,8 +3839,8 @@
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/typewrapper/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/weak/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/rapidjson/include",
+					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/expected-lite/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/polylabel/include",
-					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/expected/include",
 					"$(PROJECT_DIR)/../../platform/darwin/include",
 				);
 				INFOPLIST_FILE = "Integration Tests/Info.plist";
@@ -3883,8 +3883,8 @@
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/typewrapper/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/weak/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/rapidjson/include",
+					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/expected-lite/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/polylabel/include",
-					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/expected/include",
 					"$(PROJECT_DIR)/../../platform/darwin/include",
 				);
 				INFOPLIST_FILE = "Integration Tests/Info.plist";
@@ -4191,8 +4191,8 @@
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/typewrapper/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/weak/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/rapidjson/include",
+					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/expected-lite/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/polylabel/include",
-					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/expected/include",
 					"$(PROJECT_DIR)/../../platform/darwin/include",
 				);
 				INFOPLIST_FILE = test/Info.plist;
@@ -4244,8 +4244,8 @@
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/typewrapper/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/weak/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/rapidjson/include",
+					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/expected-lite/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/polylabel/include",
-					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/expected/include",
 					"$(PROJECT_DIR)/../../platform/darwin/include",
 				);
 				INFOPLIST_FILE = "Integration Tests/Info.plist";
@@ -4470,8 +4470,8 @@
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/typewrapper/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/weak/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/rapidjson/include",
+					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/expected-lite/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/polylabel/include",
-					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/expected/include",
 					"$(PROJECT_DIR)/../../platform/darwin/include",
 				);
 				INFOPLIST_FILE = test/Info.plist;
@@ -4511,8 +4511,8 @@
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/typewrapper/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/mapbox/weak/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/rapidjson/include",
+					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/mapbox-base/extras/expected-lite/include",
 					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/polylabel/include",
-					"$(PROJECT_DIR)/../../vendor/mapbox-gl-native/vendor/expected/include",
 					"$(PROJECT_DIR)/../../platform/darwin/include",
 				);
 				INFOPLIST_FILE = test/Info.plist;

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog for Mapbox Maps SDK for macOS
 
 ## master
-
+* Added support for [image expression](https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-types-image) in core library. Runtime APIs for image expression will be implemented separately. ([#15877](https://github.com/mapbox/mapbox-gl-native/pull/15877))
 * Fixed crashes triggered when `MGLSource` and `MGLStyleLayer` objects are accessed after having been invalidated after a style change. ([#15539](https://github.com/mapbox/mapbox-gl-native/pull/15539))
 * Fixed an issue where it was possible to set the map’s content insets then tilt the map enough to see the horizon, causing performance issues. ([#15195](https://github.com/mapbox/mapbox-gl-native/pull/15195))
 * Added an `MGLMapView.prefetchesTiles` property to configure lower-resolution tile prefetching behavior. ([#14816](https://github.com/mapbox/mapbox-gl-native/pull/14816))

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Added an `-[MGLMapSnapshotter startWithOverlayHandler:completionHandler:]` method to provide the snapshot's current `CGContext` in order to perform custom drawing on `MGLMapSnapShot` objects. ([#15530](https://github.com/mapbox/mapbox-gl-native/pull/15530))
 * Fixed an issue that `maxzoom` in style `Sources` option was ignored when URL resource is provided. It may cause problems such as extra tiles downloading at higher zoom level than `maxzoom`, or problems that wrong setting of `overscaledZ` in `OverscaledTileID` that will be passed to `SymbolLayout`, leading wrong rendering appearance. ([#15581](https://github.com/mapbox/mapbox-gl-native/pull/15581))
 * Fixed a crash when `-[MGLOfflinePack invalidate]` is called on different threads. ([#15582](https://github.com/mapbox/mapbox-gl-native/pull/15582))
+* Make network requests for expired resources lower priority than requests for new resources. ([#15950](https://github.com/mapbox/mapbox-gl-native/pull/15950))
 
 ### Styles and rendering
 


### PR DESCRIPTION
Update the changelog and `mapbox-gl-native` submodule in order to prepare for the 5.6.0-alpha.1 release. Also applied patches for platform code updates.

cc @julianrex 