### PR TITLE
Bump Xcode 11 builds to 11.2.1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -256,7 +256,7 @@ commands:
 jobs:
   ios-debug:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.2.1"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -304,7 +304,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-sanitize-nightly:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.2.1"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -331,7 +331,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-sanitize-address-nightly:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.2.1"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -351,7 +351,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-static-analyzer-nightly:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.2.1"
     environment:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -391,7 +391,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-release-template:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.2.1"
     shell: /bin/bash --login -eo pipefail
     environment:
       BUILDTYPE: Release
@@ -443,7 +443,7 @@ jobs:
 # ------------------------------------------------------------------------------
   ios-release-tag:
     macos:
-      xcode: "11.0.0"
+      xcode: "11.2.1"
     shell: /bin/bash --login -eo pipefail
     environment:
       BUILDTYPE: Release


### PR DESCRIPTION
Seeing 
```
2019-11-25 12:21:08.315 xcodebuild[4648:15473] [MT] DVTAssertions: Warning in /Library/Caches/com.apple.xbs/Sources/DVTiOSFrameworks/DVTiOSFrameworks-14802/IDEiOSSupportCore/DVTiPhoneSimulator.m:1890
Details:  [DVTiPhoneSimulator -primaryInstrumentsServer was called from the main thread
Object:   <DVTiPhoneSimulator: 0x7fc18cba77b0>
Method:   -primaryInstrumentsServerWithError:
Thread:   <NSThread: 0x7fc18a415650>{number = 1, name = main}
Please file a bug at https://feedbackassistant.apple.com with this warning message and any useful information you can provide.
```
in some PRs (e.g. https://circleci.com/gh/mapbox/mapbox-gl-native-ios/1380) - updating Xcode to see if this helps.

Update: This appears to be an issue with simulators: https://forums.developer.apple.com/thread/123020#392637