### PR TITLE
Add timeout for ios-release-tag

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -465,6 +465,7 @@ jobs:
           command: |
             export VERSION_TAG=${CIRCLE_TAG}
             platform/ios/scripts/deploy-packages.sh
+            no_output_timeout: 20m
       - deploy:
           name: Deploy to CocoaPods
           command: platform/ios/scripts/deploy-to-cocoapods.sh


### PR DESCRIPTION
Temporarily bump timeout for `ios-release-tag` (see also #71)