### PR TITLE
Bump podspec and submodules

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,6 +4,8 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ## 5.6.0
 
+* No public-facing changes in v5.6.0-alpha.2.
+
 ### Packaging
 * Integrates [`MapboxMobileEvents`](https://github.com/mapbox/mapbox-events-ios) as a dependency. ([#60](https://github.com/mapbox/mapbox-gl-native-ios/pull/60))
     - CocoaPods: no change.

--- a/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '5.6.0-alpha.1'
+  version = '5.6.0-alpha.2'
 
   m.name    = 'Mapbox-iOS-SDK-snapshot-dynamic'
   m.version = "#{version}-snapshot"
@@ -29,6 +29,6 @@ Pod::Spec.new do |m|
 
   m.preserve_path = '**/*.bcsymbolmap'
 
-  m.dependency "MapboxMobileEvents", "0.10.1-alpha"
+  m.dependency "MapboxMobileEvents", "0.10.1"
 
 end

--- a/platform/ios/Mapbox-iOS-SDK-stripped.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-stripped.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '5.6.0-alpha.1'
+  version = '5.6.0-alpha.2'
 
   m.name    = 'Mapbox-iOS-SDK-stripped'
   m.version = "#{version}-stripped"
@@ -29,6 +29,6 @@ Pod::Spec.new do |m|
 
   m.preserve_path = '**/*.bcsymbolmap'
 
-  m.dependency "MapboxMobileEvents", "0.10.1-alpha"
+  m.dependency "MapboxMobileEvents", "0.10.1"
 
 end

--- a/platform/ios/Mapbox-iOS-SDK.podspec
+++ b/platform/ios/Mapbox-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '5.6.0-alpha.1'
+  version = '5.6.0-alpha.2'
 
   m.name    = 'Mapbox-iOS-SDK'
   m.version = version
@@ -29,5 +29,5 @@ Pod::Spec.new do |m|
 
   m.preserve_path = '**/*.bcsymbolmap'
 
-  m.dependency "MapboxMobileEvents", "0.10.1-alpha"
+  m.dependency "MapboxMobileEvents", "0.10.1"
 end


### PR DESCRIPTION
Bumps the podspec to v5.6.0-alpha.2 and updates the events submodule to v0.10.1