### PR TITLE
Remove Android Transifex configuration

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -43,11 +43,3 @@ lang_map = pt_BR: pt-BR, pt_PT: pt-PT, zh_CN: zh-Hans, zh_TW: zh-Hant
 source_file = platform/ios/app/Settings.bundle/Base.lproj/Root.strings
 source_lang = en
 type = STRINGS
-
-[mapbox-gl-native.stringsxml-android]
-file_filter = platform/android/MapboxGLAndroidSDK/src/main/res/values-<lang>/strings.xml
-lang_map = pt_PT: pt-rPT, zh_CN: zh-rCN, zh_TW: zh-rTW, zh_HK: zh-rHK
-source_file = platform/android/MapboxGLAndroidSDK/src/main/res/values/strings.xml
-source_lang = en
-type = ANDROID
-


### PR DESCRIPTION
The Android map SDK codebase has been removed from this iOS/macOS fork of the gl-native repository, so this PR removes an Android file path from the Transifex configuration.

/cc @mapbox/maps-ios