### PR TITLE
Declare mbgl::style::GeoJSONOptions as immutable

### DIFF
--- a/platform/darwin/src/MGLShapeSource.mm
+++ b/platform/darwin/src/MGLShapeSource.mm
@@ -27,7 +27,7 @@ const MGLShapeSourceOption MGLShapeSourceOptionMinimumZoomLevel = @"MGLShapeSour
 const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance = @"MGLShapeSourceOptionSimplificationTolerance";
 const MGLShapeSourceOption MGLShapeSourceOptionLineDistanceMetrics = @"MGLShapeSourceOptionLineDistanceMetrics";
 
-mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShapeSourceOption, id> *options) {
+mbgl::Immutable<mbgl::style::GeoJSONOptions> MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShapeSourceOption, id> *options) {
     auto geoJSONOptions = mbgl::style::GeoJSONOptions();
 
     if (NSNumber *value = options[MGLShapeSourceOptionMinimumZoomLevel]) {
@@ -145,7 +145,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
         geoJSONOptions.lineMetrics = value.boolValue;
     }
 
-    return geoJSONOptions;
+    return mbgl::makeMutable<mbgl::style::GeoJSONOptions>(std::move(geoJSONOptions));
 }
 
 @interface MGLShapeSource ()

--- a/platform/darwin/src/MGLShapeSource_Private.h
+++ b/platform/darwin/src/MGLShapeSource_Private.h
@@ -1,5 +1,6 @@
 #import "MGLFoundation.h"
 #import "MGLShapeSource.h"
+#include <mbgl/util/immutable.hpp>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -10,7 +11,7 @@ namespace mbgl {
 }
 
 MGL_EXPORT
-mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShapeSourceOption, id> *options);
+mbgl::Immutable<mbgl::style::GeoJSONOptions> MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShapeSourceOption, id> *options);
 
 @interface MGLShapeSource (Private)
 


### PR DESCRIPTION
Attempts to fix crash in noted in https://github.com/mapbox/mapbox-gl-native/issues/16053 by declaring `mbgl::style::GeoJSONOptions` as an `Immutable` type.

Per chat with @asheemmamoowala, Android has implemented this [in their own platform JNI code](https://github.com/mapbox/mapbox-gl-native/blob/597757df6aba1ae8c4477706142823303f020de7/src/mbgl/style/sources/geojson_source_impl.cpp#L125) so they don't run into this issue. To be consistent, we should do the same on iOS.

So far, all of the changes in this PR seem to resolve the errors from https://github.com/mapbox/mapbox-gl-native/issues/16053, but I'm still running into an issue related to `lmbgl-vendor-icu` - running iosapp in this PR results in the build failing with `Library not found for -lmbgl-vendor-icu`:

<img width="428" alt="Screenshot 2019-12-12 16 41 15" src="https://user-images.githubusercontent.com/10850812/70760368-50238f00-1cfe-11ea-978b-5cd75d973afd.png">

I'm not aware of what this library is used for. @asheemmamoowala has mentioned that @pozdnyakov may be able to diagnose this further.

Note: This PR also has the mapbox-gl-native PR pointed at the `release-tequila` branch.

cc @mapbox/ios 