### PR TITLE
Podspec / submodule updates for 5.6.0-beta.1, adapt to gl-native immutable GeoJSON sources (V2)

### DIFF
--- a/platform/darwin/src/MGLShapeSource.mm
+++ b/platform/darwin/src/MGLShapeSource.mm
@@ -27,15 +27,15 @@ const MGLShapeSourceOption MGLShapeSourceOptionMinimumZoomLevel = @"MGLShapeSour
 const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance = @"MGLShapeSourceOptionSimplificationTolerance";
 const MGLShapeSourceOption MGLShapeSourceOptionLineDistanceMetrics = @"MGLShapeSourceOptionLineDistanceMetrics";
 
-mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShapeSourceOption, id> *options) {
-    auto geoJSONOptions = mbgl::style::GeoJSONOptions();
+mbgl::Immutable<mbgl::style::GeoJSONOptions> MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShapeSourceOption, id> *options) {
+    auto geoJSONOptions = mbgl::makeMutable<mbgl::style::GeoJSONOptions>();
 
     if (NSNumber *value = options[MGLShapeSourceOptionMinimumZoomLevel]) {
         if (![value isKindOfClass:[NSNumber class]]) {
             [NSException raise:NSInvalidArgumentException
                         format:@"MGLShapeSourceOptionMaximumZoomLevel must be an NSNumber."];
         }
-        geoJSONOptions.minzoom = value.integerValue;
+        geoJSONOptions->minzoom = value.integerValue;
     }
 
     if (NSNumber *value = options[MGLShapeSourceOptionMaximumZoomLevel]) {
@@ -43,7 +43,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
             [NSException raise:NSInvalidArgumentException
                         format:@"MGLShapeSourceOptionMaximumZoomLevel must be an NSNumber."];
         }
-        geoJSONOptions.maxzoom = value.integerValue;
+        geoJSONOptions->maxzoom = value.integerValue;
     }
 
     if (NSNumber *value = options[MGLShapeSourceOptionBuffer]) {
@@ -51,7 +51,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
             [NSException raise:NSInvalidArgumentException
                         format:@"MGLShapeSourceOptionBuffer must be an NSNumber."];
         }
-        geoJSONOptions.buffer = value.integerValue;
+        geoJSONOptions->buffer = value.integerValue;
     }
 
     if (NSNumber *value = options[MGLShapeSourceOptionSimplificationTolerance]) {
@@ -59,7 +59,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
             [NSException raise:NSInvalidArgumentException
                         format:@"MGLShapeSourceOptionSimplificationTolerance must be an NSNumber."];
         }
-        geoJSONOptions.tolerance = value.doubleValue;
+        geoJSONOptions->tolerance = value.doubleValue;
     }
 
     if (NSNumber *value = options[MGLShapeSourceOptionClusterRadius]) {
@@ -67,7 +67,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
             [NSException raise:NSInvalidArgumentException
                         format:@"MGLShapeSourceOptionClusterRadius must be an NSNumber."];
         }
-        geoJSONOptions.clusterRadius = value.integerValue;
+        geoJSONOptions->clusterRadius = value.integerValue;
     }
 
     if (NSNumber *value = options[MGLShapeSourceOptionMaximumZoomLevelForClustering]) {
@@ -75,7 +75,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
             [NSException raise:NSInvalidArgumentException
                         format:@"MGLShapeSourceOptionMaximumZoomLevelForClustering must be an NSNumber."];
         }
-        geoJSONOptions.clusterMaxZoom = value.integerValue;
+        geoJSONOptions->clusterMaxZoom = value.integerValue;
     }
 
     if (NSNumber *value = options[MGLShapeSourceOptionClustered]) {
@@ -83,7 +83,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
             [NSException raise:NSInvalidArgumentException
                         format:@"MGLShapeSourceOptionClustered must be an NSNumber."];
         }
-        geoJSONOptions.cluster = value.boolValue;
+        geoJSONOptions->cluster = value.boolValue;
     }
 
     if (NSDictionary *value = options[MGLShapeSourceOptionClusterProperties]) {
@@ -133,7 +133,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
 
             std::string keyString = std::string([key UTF8String]);
 
-            geoJSONOptions.clusterProperties.emplace(keyString, std::make_pair(std::move(map), std::move(reduce)));
+            geoJSONOptions->clusterProperties.emplace(keyString, std::make_pair(std::move(map), std::move(reduce)));
         }
     }
 
@@ -142,7 +142,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
             [NSException raise:NSInvalidArgumentException
                         format:@"MGLShapeSourceOptionLineDistanceMetrics must be an NSNumber."];
         }
-        geoJSONOptions.lineMetrics = value.boolValue;
+        geoJSONOptions->lineMetrics = value.boolValue;
     }
 
     return geoJSONOptions;
@@ -159,7 +159,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
 
 - (instancetype)initWithIdentifier:(NSString *)identifier URL:(NSURL *)url options:(NSDictionary<NSString *, id> *)options {
     auto geoJSONOptions = MGLGeoJSONOptionsFromDictionary(options);
-    auto source = std::make_unique<mbgl::style::GeoJSONSource>(identifier.UTF8String, geoJSONOptions);
+    auto source = std::make_unique<mbgl::style::GeoJSONSource>(identifier.UTF8String, std::move(geoJSONOptions));
     if (self = [super initWithPendingSource:std::move(source)]) {
         self.URL = url;
     }
@@ -168,7 +168,7 @@ mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShap
 
 - (instancetype)initWithIdentifier:(NSString *)identifier shape:(nullable MGLShape *)shape options:(NSDictionary<MGLShapeSourceOption, id> *)options {
     auto geoJSONOptions = MGLGeoJSONOptionsFromDictionary(options);
-    auto source = std::make_unique<mbgl::style::GeoJSONSource>(identifier.UTF8String, geoJSONOptions);
+    auto source = std::make_unique<mbgl::style::GeoJSONSource>(identifier.UTF8String, std::move(geoJSONOptions));
     if (self = [super initWithPendingSource:std::move(source)]) {
         if ([shape isMemberOfClass:[MGLShapeCollection class]]) {
             static dispatch_once_t onceToken;

--- a/platform/darwin/src/MGLShapeSource_Private.h
+++ b/platform/darwin/src/MGLShapeSource_Private.h
@@ -1,5 +1,6 @@
 #import "MGLFoundation.h"
 #import "MGLShapeSource.h"
+#include <mbgl/util/immutable.hpp>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -10,7 +11,7 @@ namespace mbgl {
 }
 
 MGL_EXPORT
-mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShapeSourceOption, id> *options);
+mbgl::Immutable<mbgl::style::GeoJSONOptions> MGLGeoJSONOptionsFromDictionary(NSDictionary<MGLShapeSourceOption, id> *options);
 
 @interface MGLShapeSource (Private)
 

--- a/platform/darwin/test/MGLShapeSourceTests.mm
+++ b/platform/darwin/test/MGLShapeSourceTests.mm
@@ -26,14 +26,14 @@
                               MGLShapeSourceOptionLineDistanceMetrics: @YES};
 
     auto mbglOptions = MGLGeoJSONOptionsFromDictionary(options);
-    XCTAssertTrue(mbglOptions.cluster);
-    XCTAssertEqual(mbglOptions.clusterRadius, 42);
-    XCTAssertEqual(mbglOptions.clusterMaxZoom, 98);
-    XCTAssertEqual(mbglOptions.maxzoom, 99);
-    XCTAssertEqual(mbglOptions.buffer, 1976);
-    XCTAssertEqual(mbglOptions.tolerance, 0.42);
-    XCTAssertTrue(mbglOptions.lineMetrics);
-    XCTAssertTrue(!mbglOptions.clusterProperties.empty());
+    XCTAssertTrue(mbglOptions->cluster);
+    XCTAssertEqual(mbglOptions->clusterRadius, 42);
+    XCTAssertEqual(mbglOptions->clusterMaxZoom, 98);
+    XCTAssertEqual(mbglOptions->maxzoom, 99);
+    XCTAssertEqual(mbglOptions->buffer, 1976);
+    XCTAssertEqual(mbglOptions->tolerance, 0.42);
+    XCTAssertTrue(mbglOptions->lineMetrics);
+    XCTAssertTrue(!mbglOptions->clusterProperties.empty());
 
     options = @{MGLShapeSourceOptionClustered: @"number 1"};
     XCTAssertThrows(MGLGeoJSONOptionsFromDictionary(options));

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -7,10 +7,10 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * No public-facing changes in v5.6.0-beta.1.
 
 ### Packaging
-* Integrates [`MapboxMobileEvents`](https://github.com/mapbox/mapbox-events-ios) as a dependency. ([#60](https://github.com/mapbox/mapbox-gl-native-ios/pull/60))
-    - CocoaPods: no change.
-    - Carthage: as an interim measure, please specify `github "mapbox/mapbox-events-ios" == 0.10.1-alpha` in your Cartfile.
-    - Manual installation: New Github release artifact (`mapbox-ios-sdk-5.6.0-alpha.1-dynamic-with-events.zip`) contains the `MapboxMobileEvents.framework`; please install this along with `Mapbox.framework`
+* Integrates [`MapboxMobileEvents`](https://github.com/mapbox/mapbox-events-ios) as a dependency ([#60](https://github.com/mapbox/mapbox-gl-native-ios/pull/60)). As a result, the following installation processes have changed:
+    - CocoaPods: You now must include `use frameworks!` in your Podfile.
+    - Carthage: Specify `github "mapbox/mapbox-events-ios" == 0.10.2-alpha` in your Cartfile. Additionally, please note that if you are using `--no-use-binaries`, the `MapboxMobileEvents.framework` will still be installed as a dynamic framework.
+    - Manual installation: New Github release artifact (`mapbox-ios-sdk-5.6.0-beta.2-dynamic-with-events.zip`) contains the `MapboxMobileEvents.framework`; please install this along with `Mapbox.framework`
 
 ### Networking and storage
 * Make network requests for expired resources lower priority than requests for new resources. ([#15950](https://github.com/mapbox/mapbox-gl-native/pull/15950))

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -10,7 +10,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Integrates [`MapboxMobileEvents`](https://github.com/mapbox/mapbox-events-ios) as a dependency ([#60](https://github.com/mapbox/mapbox-gl-native-ios/pull/60)). As a result, the following installation processes have changed:
     - CocoaPods: You now must include `use frameworks!` in your Podfile.
     - Carthage: Specify `github "mapbox/mapbox-events-ios" == 0.10.2` in your Cartfile. Additionally, please note that if you are using `--no-use-binaries`, the `MapboxMobileEvents.framework` will still be installed as a dynamic framework.
-    - Manual installation: New Github release artifact (`mapbox-ios-sdk-5.6.0-beta.2-dynamic-with-events.zip`) contains the `MapboxMobileEvents.framework`; please install this along with `Mapbox.framework`
+    - Manual installation: New Github release artifact (`mapbox-ios-sdk-5.6.0-beta.1-dynamic-with-events.zip`) contains the `MapboxMobileEvents.framework`; please install this along with `Mapbox.framework`
 
 ### Networking and storage
 * Make network requests for expired resources lower priority than requests for new resources. ([#15950](https://github.com/mapbox/mapbox-gl-native/pull/15950))

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,7 +4,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ## 5.6.0
 
-* No public-facing changes in v5.6.0-alpha.2.
+* No public-facing changes in v5.6.0-beta.1.
 
 ### Packaging
 * Integrates [`MapboxMobileEvents`](https://github.com/mapbox/mapbox-events-ios) as a dependency. ([#60](https://github.com/mapbox/mapbox-gl-native-ios/pull/60))

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -9,7 +9,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 ### Packaging
 * Integrates [`MapboxMobileEvents`](https://github.com/mapbox/mapbox-events-ios) as a dependency ([#60](https://github.com/mapbox/mapbox-gl-native-ios/pull/60)). As a result, the following installation processes have changed:
     - CocoaPods: You now must include `use frameworks!` in your Podfile.
-    - Carthage: Specify `github "mapbox/mapbox-events-ios" == 0.10.2-alpha` in your Cartfile. Additionally, please note that if you are using `--no-use-binaries`, the `MapboxMobileEvents.framework` will still be installed as a dynamic framework.
+    - Carthage: Specify `github "mapbox/mapbox-events-ios" == 0.10.2` in your Cartfile. Additionally, please note that if you are using `--no-use-binaries`, the `MapboxMobileEvents.framework` will still be installed as a dynamic framework.
     - Manual installation: New Github release artifact (`mapbox-ios-sdk-5.6.0-beta.2-dynamic-with-events.zip`) contains the `MapboxMobileEvents.framework`; please install this along with `Mapbox.framework`
 
 ### Networking and storage

--- a/platform/ios/INSTALL.md
+++ b/platform/ios/INSTALL.md
@@ -178,7 +178,7 @@ To test pre-releases of the dynamic framework, directly specify the version in y
 
 ```json
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> x.x.x-alpha.1
-github "mapbox/mapbox-events-ios" == 0.10.2-alpha
+github "mapbox/mapbox-events-ios" == 0.10.2
 ```
 
 ##### Testing snapshot releases with Carthage

--- a/platform/ios/INSTALL.md
+++ b/platform/ios/INSTALL.md
@@ -111,6 +111,8 @@ For instructions on installing stable release versions of the Mapbox Maps SDK fo
 To test pre-releases of the dynamic framework, directly specify the version in your `Podfile`:
 
 ```rb
+use frameworks!
+
 pod 'Mapbox-iOS-SDK', '~> x.x.x-alpha.1'
 ```
 
@@ -119,6 +121,8 @@ pod 'Mapbox-iOS-SDK', '~> x.x.x-alpha.1'
 To test a snapshot dynamic framework build, update your app’s `Podfile` to point to:
 
 ```rb
+use frameworks!
+
 pod 'Mapbox-iOS-SDK-snapshot-dynamic', podspec: 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native-ios/master/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec'
 ```
 
@@ -139,6 +143,8 @@ pod 'Mapbox-iOS-SDK-snapshot-dynamic', podspec: 'https://raw.githubusercontent.c
 1. Update your app’s `Podfile` to point to the edited `Mapbox-iOS-SDK.podspec`.
 
     ```rb
+    use frameworks!
+
     pod 'Mapbox-iOS-SDK', :path => '{...}/platform/ios/Mapbox-iOS-SDK.podspec'
     ```
 
@@ -151,6 +157,8 @@ If using the static framework, add `$(inherited)` to your target’s Other Linke
 If you choose to commit the contents of your `Pods` directory to source control and are encountering file size limitations, you may wish to use builds that have been pre-stripped of debug symbols. We publish these to [our public podspecs repository](https://github.com/mapbox/pod-specs/), which should be added as an additional `source` in your app’s `Podfile`.
 
 ```rb
+use frameworks!
+
 source 'https://github.com/mapbox/pod-specs.git'
 
 pod 'Mapbox-iOS-SDK-stripped', '~> x.x.x'
@@ -162,12 +170,15 @@ Note that these builds lack some debugging information, which could make develop
 
 For instructions on installing stable release versions of the Mapbox Maps SDK for iOS with Carthage, see [our website](https://www.mapbox.com/install/ios/carthage/).
 
+Please note that as of ios-v5.6.0-alpha.2, `--no-use-binaries` has no affect on projects built with the Mapbox framework.
+
 ##### Testing pre-releases with Carthage
 
 To test pre-releases of the dynamic framework, directly specify the version in your Cartfile:
 
 ```json
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> x.x.x-alpha.1
+github "mapbox/mapbox-events-ios" == 0.10.2-alpha
 ```
 
 ##### Testing snapshot releases with Carthage

--- a/platform/ios/INSTALL.md
+++ b/platform/ios/INSTALL.md
@@ -106,13 +106,13 @@ You can alternatively install the SDK as a static framework:
 
 For instructions on installing stable release versions of the Mapbox Maps SDK for iOS with CocoaPods, see [our website](https://www.mapbox.com/install/ios/cocoapods/).
 
+As of v5.6.0, you must specify `use_frameworks!` in your Podfile.
+
 ##### Testing pre-releases with CocoaPods
 
 To test pre-releases of the dynamic framework, directly specify the version in your `Podfile`:
 
 ```rb
-use frameworks!
-
 pod 'Mapbox-iOS-SDK', '~> x.x.x-alpha.1'
 ```
 
@@ -121,8 +121,6 @@ pod 'Mapbox-iOS-SDK', '~> x.x.x-alpha.1'
 To test a snapshot dynamic framework build, update your app’s `Podfile` to point to:
 
 ```rb
-use frameworks!
-
 pod 'Mapbox-iOS-SDK-snapshot-dynamic', podspec: 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native-ios/master/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec'
 ```
 
@@ -143,8 +141,6 @@ pod 'Mapbox-iOS-SDK-snapshot-dynamic', podspec: 'https://raw.githubusercontent.c
 1. Update your app’s `Podfile` to point to the edited `Mapbox-iOS-SDK.podspec`.
 
     ```rb
-    use frameworks!
-
     pod 'Mapbox-iOS-SDK', :path => '{...}/platform/ios/Mapbox-iOS-SDK.podspec'
     ```
 
@@ -157,8 +153,6 @@ If using the static framework, add `$(inherited)` to your target’s Other Linke
 If you choose to commit the contents of your `Pods` directory to source control and are encountering file size limitations, you may wish to use builds that have been pre-stripped of debug symbols. We publish these to [our public podspecs repository](https://github.com/mapbox/pod-specs/), which should be added as an additional `source` in your app’s `Podfile`.
 
 ```rb
-use frameworks!
-
 source 'https://github.com/mapbox/pod-specs.git'
 
 pod 'Mapbox-iOS-SDK-stripped', '~> x.x.x'
@@ -178,8 +172,10 @@ To test pre-releases of the dynamic framework, directly specify the version in y
 
 ```json
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> x.x.x-alpha.1
-github "mapbox/mapbox-events-ios" == 0.10.2
+github "mapbox/mapbox-events-ios" == x.x.x
 ```
+
+Where `x.x.x` is the latest version of the [Mapbox Mobile Events](https://github.com/mapbox/mapbox-events-ios) library.
 
 ##### Testing snapshot releases with Carthage
 

--- a/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '5.6.0-alpha.2'
+  version = '5.6.0-beta.1'
 
   m.name    = 'Mapbox-iOS-SDK-snapshot-dynamic'
   m.version = "#{version}-snapshot"

--- a/platform/ios/Mapbox-iOS-SDK-stripped.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-stripped.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '5.6.0-alpha.2'
+  version = '5.6.0-beta.1'
 
   m.name    = 'Mapbox-iOS-SDK-stripped'
   m.version = "#{version}-stripped"

--- a/platform/ios/Mapbox-iOS-SDK.podspec
+++ b/platform/ios/Mapbox-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '5.6.0-alpha.2'
+  version = '5.6.0-beta.1'
 
   m.name    = 'Mapbox-iOS-SDK'
   m.version = version


### PR DESCRIPTION
This PR 

- Updates the Podspecs to 5.6.0-beta.1.
- Updates the `vendor/mapbox-gl-native` submodule to point to `release-tequila` (..properly 😅).
- Adapts minor Obj-C++ code to avoid a crash when using sources (see https://github.com/mapbox/mapbox-gl-native/issues/16053)
- Updates `Install.md` to account for a changed installation process now that MapboxMobileEvents.framework is included as a dependency.