### PR TITLE
Introduce limited axis scrolling

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## master
+
+### Other changes
+* Added new property `MGLMapView.panScrollingMode`, which allows you to limit the horizontal or vertical direction a user may pan on the map view. ([#108](https://github.com/mapbox/mapbox-gl-native-ios/pull/108))
+
 ## 5.6.0 - December 19, 2019
 This release includes a known issue where the binary size has increased. [#63](https://github.com/mapbox/mapbox-gl-native-ios/issues/63)
 

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -105,6 +105,15 @@ typedef NS_ENUM(NSUInteger, MGLUserTrackingMode) {
     MGLUserTrackingModeFollowWithCourse,
 };
 
+typedef NS_ENUM(NSUInteger, MGLPanScrollingMode) {
+    /** The map allows the user to only scroll horizontally. */
+    MGLPanScrollingModeHorizontal               = 0,
+    /** The map allows the user to only scroll vertically. */
+    MGLPanScrollingModeVertical,
+    /** The map allows the user to scroll both horizontally and vertically. */
+    MGLPanScrollingModeDefault
+};
+
 /** Options for `MGLMapView.preferredFramesPerSecond`. */
 typedef NSInteger MGLMapViewPreferredFramesPerSecond NS_TYPED_EXTENSIBLE_ENUM;
 
@@ -688,6 +697,20 @@ MGL_EXPORT
  programmatically.
  */
 @property(nonatomic, getter=isScrollEnabled) BOOL scrollEnabled;
+
+/**
+ The scrolling mode the user is allowed to use to interact with the map.
+
+`MGLPanScrollingModeHorizontal` only allows the user to scroll horizontally on the map,
+ restricting a user's ability to scroll vertically.
+`MGLPanScrollingModeVertical` only allows the user to scroll vertically on the map,
+ restricting a user's ability to scroll horizontally.
+ `MGLPanScrollingModeDefault` allows the user to scroll both horizontally and vertically
+ on the map.
+
+ By default, this property is set to `MGLPanScrollingModeDefault`.
+ */
+@property (nonatomic, assign) MGLPanScrollingMode panScrollingMode;
 
 /**
  A Boolean value that determines whether the user may rotate the map,

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -586,6 +586,7 @@ public:
     _pan.maximumNumberOfTouches = 1;
     [self addGestureRecognizer:_pan];
     _scrollEnabled = YES;
+    _panScrollingMode = MGLPanScrollingModeDefault;
 
     _pinch = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(handlePinchGesture:)];
     _pinch.delegate = self;
@@ -1730,7 +1731,17 @@ public:
 
         if ([self _shouldChangeFromCamera:oldCamera toCamera:toCamera])
         {
-            self.mbglMap.moveBy({ delta.x, delta.y });
+            switch(self.panScrollingMode){
+               case MGLPanScrollingModeVertical:
+                  self.mbglMap.moveBy({ 0, delta.y });
+                  break;
+               case MGLPanScrollingModeHorizontal:
+                  self.mbglMap.moveBy({ delta.x, 0 });
+                  break;
+               default:
+                  self.mbglMap.moveBy({ delta.x, delta.y });
+            }
+
             [pan setTranslation:CGPointZero inView:pan.view];
         }
 
@@ -1753,7 +1764,16 @@ public:
 
             if ([self _shouldChangeFromCamera:oldCamera toCamera:toCamera])
             {
-                self.mbglMap.moveBy({ offset.x, offset.y }, MGLDurationFromTimeInterval(self.decelerationRate));
+                switch(self.panScrollingMode){
+                   case MGLPanScrollingModeVertical:
+                      self.mbglMap.moveBy({ 0, offset.y }, MGLDurationFromTimeInterval(self.decelerationRate));
+                      break;
+                   case MGLPanScrollingModeHorizontal:
+                      self.mbglMap.moveBy({ offset.x, 0 }, MGLDurationFromTimeInterval(self.decelerationRate));
+                      break;
+                   default:
+                      self.mbglMap.moveBy({ offset.x, offset.y }, MGLDurationFromTimeInterval(self.decelerationRate));
+                }
             }
         }
 


### PR DESCRIPTION
Addresses https://github.com/mapbox/mapbox-gl-native-ios/issues/107 by introducing a new option to limit vertical and horizontal scrolling.

Developers can limit scrolling for users both horizontally or vertically with this change.

Usage:

```objc
mapView.scrollingMode = MGLPanScrollingModeVertical
```

or 

```objc
mapView.scrollingMode = MGLPanScrollingModeHorizontal
```

Default:

```objc
mapView.scrollingMode = MGLPanScrollingModeDefault
```

Below is an example of setting `MGLPanScrollingModeVertical`:

![scrollington_boat_factory](https://user-images.githubusercontent.com/10850812/70950019-42c71700-2014-11ea-85fe-4cfe85abc4e1.gif)
