### PR TITLE
Copy static headers from correct directory

### DIFF
--- a/platform/ios/scripts/package.sh
+++ b/platform/ios/scripts/package.sh
@@ -238,9 +238,9 @@ fi
 
 if [[ ${BUILD_STATIC} == true ]]; then
     step "Copying static library headers…"
-    cp -rv "${PRODUCTS}/${BUILDTYPE}-iphoneos/Headers" "${OUTPUT}/static/${NAME}.framework/Headers"
+    cp -rv "${PRODUCTS}/${BUILDTYPE}-${SDK}/Headers" "${OUTPUT}/static/${NAME}.framework/Headers"
     cat platform/ios/framework/Mapbox-static.h > "${OUTPUT}/static/${NAME}.framework/Headers/Mapbox.h"
-    cat "${PRODUCTS}/${BUILDTYPE}-iphoneos/Headers/Mapbox.h" >> "${OUTPUT}/static/${NAME}.framework/Headers/Mapbox.h"
+    cat "${PRODUCTS}/${BUILDTYPE}-${SDK}/Headers/Mapbox.h" >> "${OUTPUT}/static/${NAME}.framework/Headers/Mapbox.h"
 fi
 
 step "Copying library resources…"


### PR DESCRIPTION
👋 Given the following command to create a static framework,

```
make iframework BUILD_DEVICE=false FORMAT=static BUILDTYPE=Release
```

headers will be outputed to the following path
```
build/ios/RelWithDebInfo-iphonesimulator/Headers
```

However when copying over the headers, we're looking in
```
build/ios/RelWithDebInfo-iphoneos/Headers
```

resulting in the following error:

```
cp: build/ios/RelWithDebInfo-iphoneos/Headers: No such file or directory
make: *** [iframework] Error 1
```

Source:
https://github.com/mapbox/mapbox-gl-native-ios/blob/fcc68b1c9057f74fcbf0e81666fc6b86800f6be0/platform/ios/scripts/package.sh#L239-L244

This PR makes it so depending on whether `BUILD_DEVICE` is true, we copy headers over from the appropriate directory. 
