### PR TITLE
Fail the strip-frameworks script if required frameworks are not embedded.

### DIFF
--- a/platform/ios/framework/strip-frameworks.sh
+++ b/platform/ios/framework/strip-frameworks.sh
@@ -85,10 +85,12 @@ done
 
 if [[ -z $found_mapbox_sdk ]]; then
     echo "Please add Mapbox.framework to the Embed Frameworks build phase."
+    echo "See https://github.com/mapbox/mapbox-gl-native-ios/pull/150"
     exit -1
 fi
 
 if [[ -z $found_events_sdk ]]; then
     echo "Please add MapboxMobileEvents.framework to the Embed Frameworks build phase."
+    echo "See https://github.com/mapbox/mapbox-gl-native-ios/pull/150"
     exit -2
 fi

--- a/platform/ios/framework/strip-frameworks.sh
+++ b/platform/ios/framework/strip-frameworks.sh
@@ -53,6 +53,18 @@ for file in $(find . -type f -perm +111); do
   if ! [[ "$(file "$file")" == *"dynamically linked shared library"* ]]; then
     continue
   fi
+
+  # Check for required Mapbox frameworks
+  framework=$(basename $file)
+
+  if [ "$framework" = "Mapbox" ]; then
+    found_mapbox_sdk=true
+  fi
+
+  if [ "$framework" = "MapboxMobileEvents" ]; then
+    found_events_sdk=true
+  fi
+
   # Get architectures for current file
   archs="$(lipo -info "${file}" | rev | cut -d ':' -f1 | rev)"
   stripped=""
@@ -71,3 +83,12 @@ for file in $(find . -type f -perm +111); do
   fi
 done
 
+if [[ -z $found_mapbox_sdk ]]; then
+    echo "Please add Mapbox.framework to the Embed Frameworks build phase."
+    exit -1
+fi
+
+if [[ -z $found_events_sdk ]]; then
+    echo "Please add MapboxMobileEvents.framework to the Embed Frameworks build phase."
+    exit -2
+fi

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -2623,6 +2623,7 @@
 				DA1DC9481CB6C1C2006E619F /* Resources */,
 				074A7F0B2277BD67001A62D1 /* Insert Mapbox Access Token */,
 				CA0FA9E62379C39C00C9F3C9 /* Embed Frameworks */,
+				CA3061AD23D11ACA00BC59BF /* Strip Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2950,6 +2951,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "$SRCROOT/app/insert_access_token.sh\n";
+		};
+		CA3061AD23D11ACA00BC59BF /* Strip Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Strip Frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "bash \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mapbox.framework/strip-frameworks.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -399,8 +399,9 @@
 		CA0FAA07237B3BC600C9F3C9 /* Mapbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA8847D21CBAF91600AB86E3 /* Mapbox.framework */; };
 		CA0FAA08237B3BC600C9F3C9 /* MapboxMobileEvents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA96299B23731199004F1330 /* MapboxMobileEvents.framework */; };
 		CA0FAA09237B3BEA00C9F3C9 /* Mapbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA8847D21CBAF91600AB86E3 /* Mapbox.framework */; };
-		CA0FAA0A237B3BEA00C9F3C9 /* MapboxMobileEvents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA96299B23731199004F1330 /* MapboxMobileEvents.framework */; };
 		CA1B4A512099FB2200EDD491 /* MGLMapSnapshotterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CA1B4A502099FB2200EDD491 /* MGLMapSnapshotterTest.m */; };
+		CA3061B323D1252E00BC59BF /* MapboxMobileEvents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA96299B23731199004F1330 /* MapboxMobileEvents.framework */; };
+		CA3061B423D1252E00BC59BF /* MapboxMobileEvents.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CA96299B23731199004F1330 /* MapboxMobileEvents.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CA4C54FE2324948100A81659 /* MGLSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4C54FD2324948100A81659 /* MGLSourceTests.swift */; };
 		CA4EB8C720863487006AB465 /* MGLStyleLayerIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA4EB8C620863487006AB465 /* MGLStyleLayerIntegrationTests.m */; };
 		CA4F3BDE230F74C3008BAFEA /* MGLMapViewPendingBlockTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA4F3BDD230F74C3008BAFEA /* MGLMapViewPendingBlockTests.m */; };
@@ -735,6 +736,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				CA3061B423D1252E00BC59BF /* MapboxMobileEvents.framework in Embed Frameworks */,
 				CAA69DA5206DCD0E007279CD /* Mapbox.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -1349,8 +1351,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CA3061B323D1252E00BC59BF /* MapboxMobileEvents.framework in Frameworks */,
 				CA0FAA09237B3BEA00C9F3C9 /* Mapbox.framework in Frameworks */,
-				CA0FAA0A237B3BEA00C9F3C9 /* MapboxMobileEvents.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2604,6 +2606,7 @@
 				16376B2C1FFDB4B40000563E /* Frameworks */,
 				16376B2D1FFDB4B40000563E /* Resources */,
 				CAA69DA6206DCD0E007279CD /* Embed Frameworks */,
+				CA3061B223D1247600BC59BF /* Strip Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2969,6 +2972,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "bash \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mapbox.framework/strip-frameworks.sh\"\n";
+		};
+		CA3061B223D1247600BC59BF /* Strip Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Strip Frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "bash \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mapbox.framework/strip-frameworks.sh\"\n\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
This PR changes the `strip-frameworks.sh` script to fail if `Mapbox.framework` or `MapboxMobileEvents.framework` are not embedded (in the host application).

If this script fails, please make sure that the frameworks are selected as `Embed & Sign`

![Embed Sign](https://user-images.githubusercontent.com/3765757/72570990-5f14d880-388c-11ea-8306-73df9deba5f2.png)
