### PR TITLE
Add property to show whether the snapshotter logo is displayed.

### DIFF
--- a/platform/darwin/src/MGLMapSnapshotter.h
+++ b/platform/darwin/src/MGLMapSnapshotter.h
@@ -121,13 +121,13 @@ MGL_EXPORT
 
 /**
  :nodoc:
- Whether the Mapbox logo is displayed.
+ Whether the Mapbox wordmark is displayed.
 
  @note The Mapbox terms of service, which governs the use of Mapbox-hosted
  vector tiles and styles,
  <a href="https://docs.mapbox.com/help/how-mapbox-works/attribution/">requires</a> most Mapbox
- customers to display the Mapbox logo. If this applies to you, do not
- hide the logo or change its contents.
+ customers to display the Mapbox wordmark. If this applies to you, do not
+ hide the wordmark or change its contents.
  */
 @property (nonatomic, readonly) BOOL showsLogo;
 

--- a/platform/darwin/src/MGLMapSnapshotter.h
+++ b/platform/darwin/src/MGLMapSnapshotter.h
@@ -120,6 +120,7 @@ MGL_EXPORT
 @property (nonatomic) CGFloat scale;
 
 /**
+ :nodoc:
  Whether the Mapbox logo is displayed.
 
  @note The Mapbox terms of service, which governs the use of Mapbox-hosted

--- a/platform/darwin/src/MGLMapSnapshotter.h
+++ b/platform/darwin/src/MGLMapSnapshotter.h
@@ -119,6 +119,17 @@ MGL_EXPORT
  */
 @property (nonatomic) CGFloat scale;
 
+/**
+ Whether the Mapbox logo is displayed.
+
+ @note The Mapbox terms of service, which governs the use of Mapbox-hosted
+ vector tiles and styles,
+ <a href="https://docs.mapbox.com/help/how-mapbox-works/attribution/">requires</a> most Mapbox
+ customers to display the Mapbox logo. If this applies to you, do not
+ hide the logo or change its contents.
+ */
+@property (nonatomic, readonly) BOOL showsLogo;
+
 @end
 
 /**

--- a/platform/darwin/src/MGLMapSnapshotter.h
+++ b/platform/darwin/src/MGLMapSnapshotter.h
@@ -119,18 +119,6 @@ MGL_EXPORT
  */
 @property (nonatomic) CGFloat scale;
 
-/**
- :nodoc:
- Whether the Mapbox wordmark is displayed.
-
- @note The Mapbox terms of service, which governs the use of Mapbox-hosted
- vector tiles and styles,
- <a href="https://docs.mapbox.com/help/how-mapbox-works/attribution/">requires</a> most Mapbox
- customers to display the Mapbox wordmark. If this applies to you, do not
- hide the wordmark or change its contents.
- */
-@property (nonatomic, readonly) BOOL showsLogo;
-
 @end
 
 /**

--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -523,7 +523,7 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
     // Capture scale and size by value to avoid accessing self from another thread
     CGFloat scale  = self.options.scale;
     CGSize size    = self.options.size;
-    BOOL showsLogo = NO;//self.options.showsLogo;
+    BOOL showsLogo = self.options.showsLogo;
 
     // pointForFn is a copyable std::function that captures state by value: see MapSnapshotter::Impl::snapshot
     __weak __typeof__(self) weakself = self;

--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -120,6 +120,10 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
     return self;
 }
 
+- (void)setValue:(id)value forUndefinedKey:(NSString *)key {
+    MGLAssert(0, @"MGLMapSnapshotOptions does not support the key: %@", key);
+}
+
 @end
 
 @interface MGLMapSnapshot() <MGLMapSnapshotProtocol>

--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -131,15 +131,6 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
     return self;
 }
 
-- (void)setValue:(id)value forUndefinedKey:(NSString *)key {
-    MGLAssert(0, @"MGLMapSnapshotOptions does not support the key: %@", key);
-}
-
-- (id)valueForUndefinedKey:(NSString *)key {
-    MGLAssert(0, @"MGLMapSnapshotOptions does not support the key: %@", key);
-    return nil;
-}
-
 @end
 
 @interface MGLMapSnapshot() <MGLMapSnapshotProtocol>

--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -340,7 +340,7 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
         }
     }
 
-    UIImage *logoImage = showsLogo ? [MGLMapSnapshotter logoImageWithStyle:attributionInfoStyle] : nil;
+    UIImage *logoImage = [MGLMapSnapshotter logoImageWithStyle:attributionInfoStyle];
     CGSize attributionBackgroundSize = [MGLMapSnapshotter attributionTextSizeWithStyle:attributionInfoStyle attributionInfo:attributionInfo];
     
     CGRect logoImageRect = CGRectMake(MGLLogoImagePosition.x, mglImage.size.height - (MGLLogoImagePosition.y + logoImage.size.height), logoImage.size.width, logoImage.size.height);
@@ -388,7 +388,9 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
         return nil;
     }
 
-    [logoImage drawInRect:logoImageRect];
+    if (showsLogo) {
+        [logoImage drawInRect:logoImageRect];
+    }
     
     UIImage *currentImage = UIGraphicsGetImageFromCurrentImageContext();
     CGImageRef attributionImageRef = CGImageCreateWithImageInRect([currentImage CGImage], cropRect);
@@ -501,7 +503,7 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
     // Capture scale and size by value to avoid accessing self from another thread
     CGFloat scale  = self.options.scale;
     CGSize size    = self.options.size;
-    BOOL showsLogo = self.options.showsLogo;
+    BOOL showsLogo = NO;//self.options.showsLogo;
 
     // pointForFn is a copyable std::function that captures state by value: see MapSnapshotter::Impl::snapshot
     __weak __typeof__(self) weakself = self;

--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -92,6 +92,17 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
 @end
 
 @interface MGLMapSnapshotOptions ()
+
+/**
+ :nodoc:
+ Whether the Mapbox wordmark is displayed.
+
+ @note The Mapbox terms of service, which governs the use of Mapbox-hosted
+ vector tiles and styles,
+ <a href="https://docs.mapbox.com/help/how-mapbox-works/attribution/">requires</a> most Mapbox
+ customers to display the Mapbox wordmark. If this applies to you, do not
+ hide the wordmark or change its contents.
+ */
 @property (nonatomic, readwrite) BOOL showsLogo;
 @end
 
@@ -122,6 +133,11 @@ const CGFloat MGLSnapshotterMinimumPixelSize = 64;
 
 - (void)setValue:(id)value forUndefinedKey:(NSString *)key {
     MGLAssert(0, @"MGLMapSnapshotOptions does not support the key: %@", key);
+}
+
+- (id)valueForUndefinedKey:(NSString *)key {
+    MGLAssert(0, @"MGLMapSnapshotOptions does not support the key: %@", key);
+    return nil;
 }
 
 @end

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -355,12 +355,12 @@ MGL_EXPORT
 @property (nonatomic, assign) CGPoint compassViewMargins;
 
 /**
- The Mapbox logo, positioned in the lower-left corner.
+ The Mapbox wordmark, positioned in the lower-left corner.
 
  @note The Mapbox terms of service, which governs the use of Mapbox-hosted
     vector tiles and styles,
     <a href="https://docs.mapbox.com/help/how-mapbox-works/attribution/">requires</a> most Mapbox
-    customers to display the Mapbox logo. If this applies to you, do not
+    customers to display the Mapbox wordmark. If this applies to you, do not
     hide this view or change its contents.
  */
 @property (nonatomic, readonly) UIImageView *logoView;


### PR DESCRIPTION
Adds a `BOOL` property to show whether the snapshotter logo is displayed.

Please note: 

> The Mapbox terms of service, which governs the use of Mapbox-hosted vector tiles and styles,
[requires](https://docs.mapbox.com/help/how-mapbox-works/attribution/) most Mapbox customers to display the Mapbox logo. If this applies to you, do not hide the logo or change its contents.