### PR TITLE
Bumped submodule for release-unicorn

### DIFF
--- a/platform/darwin/test/MGLResourceTests.mm
+++ b/platform/darwin/test/MGLResourceTests.mm
@@ -73,12 +73,12 @@ namespace mbgl {
         for (NSURLQueryItem *item in components.queryItems) {
             if (([item.name isEqualToString:@"offline"] && [item.value isEqualToString:@"true"]) ||
                 ([item.name isEqualToString:@"a"] && [item.value isEqualToString:@"one"]) ||
-                ([item.name isEqualToString:@"b"] && [item.value isEqualToString:@"two"]) || [item.name isEqualToString:@"sku"]) {
+                ([item.name isEqualToString:@"b"] && [item.value isEqualToString:@"two"])) {
                 foundCount++;
             }
         }
 
-        XCTAssert(foundCount == 4);
+        XCTAssert(foundCount == 3);
 #else
         // NOTE: Currently the macOS SDK does not supply the sku or offline query parameters
         for (NSURLQueryItem *item in components.queryItems) {


### PR DESCRIPTION
This PR bumps the `mapbox-gl-native` submodule for the final release of v5.7.0.

cc @chloekraw @knov 