### PR TITLE
Tweaks for failing integration tests on simulators

### DIFF
--- a/platform/ios/Integration Tests/Annotation Tests/MGLAnnotationViewIntegrationTests.mm
+++ b/platform/ios/Integration Tests/Annotation Tests/MGLAnnotationViewIntegrationTests.mm
@@ -132,7 +132,15 @@ static const CGPoint kAnnotationRelativeScale = { 0.05f, 0.125f };
     // Animated selection takes MGLAnimationDuration (0.3 seconds), so wait a little
     // longer. We don't need to wait as long if we're not animated (but we do
     // want the runloop to tick over)
+
+#if TARGET_OS_SIMULATOR
+    // Something is amiss with dispatch_async & XCTest on simulators in a recent
+    // iOS SDK release.
+    // TODO: Add issue
+    [self waitForExpectations:@[selectionCompleted] timeout:animateSelection ? 0.4: 0.1];
+#else
     [self waitForExpectations:@[selectionCompleted] timeout:animateSelection ? 0.4: 0.05];
+#endif
 
     UIView *annotationViewAfterSelection =  [self.mapView viewForAnnotation:point];
     CLLocationCoordinate2D mapCenterAfterSelection = self.mapView.centerCoordinate;

--- a/platform/ios/Integration Tests/MGLMapViewIntegrationTest.m
+++ b/platform/ios/Integration Tests/MGLMapViewIntegrationTest.m
@@ -168,16 +168,9 @@
 }
 
 - (void)waitForExpectations:(NSArray<XCTestExpectation *> *)expectations timeout:(NSTimeInterval)seconds {
-
     NSTimer *timer;
 
-    if (@available(iOS 10.0, *)) {
-        // We're good.
-    }
-    else if (self.mapView) {
-        // Before iOS 10 it seems that the display link is not called during the
-        // waitForExpectations below
-        
+    if (self.mapView) {
         timer = [NSTimer scheduledTimerWithTimeInterval:1.0/30.0
                                                  target:self
                                                selector:@selector(updateMapViewDisplayLinkFromTimer:)
@@ -190,7 +183,15 @@
 }
 
 - (void)updateMapViewDisplayLinkFromTimer:(NSTimer *)timer {
-    [self.mapView updateFromDisplayLink:nil];
+    if (@available(iOS 10.0, *)) {
+        // This is required for iOS 13.?, where dispatch blocks were not being
+        // called - after being issued with
+        // dispatch_async(dispatch_get_main_queue(), ...)
+    } else {
+        // Before iOS 10 it seems that the display link is not called during the
+        // waitForExpectations below
+        [self.mapView updateFromDisplayLink:nil];
+    }
 }
 
 - (MGLStyle *)style {

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -398,13 +398,14 @@
 		CA0FAA07237B3BC600C9F3C9 /* Mapbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA8847D21CBAF91600AB86E3 /* Mapbox.framework */; };
 		CA0FAA08237B3BC600C9F3C9 /* MapboxMobileEvents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA96299B23731199004F1330 /* MapboxMobileEvents.framework */; };
 		CA0FAA09237B3BEA00C9F3C9 /* Mapbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA8847D21CBAF91600AB86E3 /* Mapbox.framework */; };
-		CA0FAA0A237B3BEA00C9F3C9 /* MapboxMobileEvents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA96299B23731199004F1330 /* MapboxMobileEvents.framework */; };
 		CA17464923D81581008B7A43 /* MGLNetworkIntegrationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = A490C46B23C688CC009AC158 /* MGLNetworkIntegrationManager.m */; };
 		CA17464A23D81587008B7A43 /* MGLNetworkIntegrationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = A490C46C23C688CC009AC158 /* MGLNetworkIntegrationManager.h */; };
 		CA17464B23D81589008B7A43 /* MGLNetworkIntegrationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = A490C46C23C688CC009AC158 /* MGLNetworkIntegrationManager.h */; };
 		CA17464C23D81595008B7A43 /* MGLNetworkIntegrationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = A490C46B23C688CC009AC158 /* MGLNetworkIntegrationManager.m */; };
 		CA17464E23D8A93C008B7A43 /* MGLNetworkConfigurationIntegrationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CA17464D23D8A93C008B7A43 /* MGLNetworkConfigurationIntegrationTests.mm */; };
 		CA1B4A512099FB2200EDD491 /* MGLMapSnapshotterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CA1B4A502099FB2200EDD491 /* MGLMapSnapshotterTest.m */; };
+		CA488BAB23FCE6B900AEE226 /* MapboxMobileEvents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA96299B23731199004F1330 /* MapboxMobileEvents.framework */; };
+		CA488BAC23FCE6B900AEE226 /* MapboxMobileEvents.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CA96299B23731199004F1330 /* MapboxMobileEvents.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CA4C54FE2324948100A81659 /* MGLSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4C54FD2324948100A81659 /* MGLSourceTests.swift */; };
 		CA4EB8C720863487006AB465 /* MGLStyleLayerIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA4EB8C620863487006AB465 /* MGLStyleLayerIntegrationTests.m */; };
 		CA4F3BDE230F74C3008BAFEA /* MGLMapViewPendingBlockTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA4F3BDD230F74C3008BAFEA /* MGLMapViewPendingBlockTests.m */; };
@@ -739,6 +740,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				CA488BAC23FCE6B900AEE226 /* MapboxMobileEvents.framework in Embed Frameworks */,
 				CAA69DA5206DCD0E007279CD /* Mapbox.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -1354,8 +1356,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CA488BAB23FCE6B900AEE226 /* MapboxMobileEvents.framework in Frameworks */,
 				CA0FAA09237B3BEA00C9F3C9 /* Mapbox.framework in Frameworks */,
-				CA0FAA0A237B3BEA00C9F3C9 /* MapboxMobileEvents.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Recently, some integration tests started failing on iOS simulators. It is not clear when or what the root cause is.

What seems to be happening is that a `dispatch_block` issued with `dispatch_async(dispatch_get_main_queue(), ...))` is not getting called as soon as is expected, meaning that test expectations are timing out.

Forcing the run loop to process *something* appears to kick the block processing in to gear, and this is what this PR does; it add a timer (that does nothing in > iOS 10) - note that the existing display link is not sufficient.

I don't believe this is iOS SDK related, and suspect that macOS Catalina may play a role here.

cc @knov @jmkiley