### PR TITLE
Update label languages for Mapbox Streets v8.3

### DIFF
--- a/platform/darwin/src/MGLVectorTileSource.mm
+++ b/platform/darwin/src/MGLVectorTileSource.mm
@@ -89,8 +89,8 @@
  https://www.mapbox.com/vector-tiles/mapbox-streets-v8/
  */
 static NSArray * const MGLMapboxStreetsLanguages = @[
-    @"ar", @"de", @"en", @"es", @"fr", @"ja", @"ko", @"pt", @"ru", @"zh",
-    @"zh-Hans",
+    @"ar", @"de", @"en", @"es", @"fr", @"ja", @"ko", @"pt", @"ru", @"vi",
+    @"zh-Hans", @"zh-Hant",
 ];
 
 /**
@@ -98,8 +98,8 @@ static NSArray * const MGLMapboxStreetsLanguages = @[
  `+[NSBundle preferredLocalizationsFromArray:forPreferences:]`.
  */
 static NSArray * const MGLMapboxStreetsAlternativeLanguages = @[
-    @"mul", @"ar", @"de", @"es", @"fr", @"ja", @"ko", @"pt", @"ru", @"zh",
-    @"zh-Hans",
+    @"mul", @"ar", @"de", @"es", @"fr", @"ja", @"ko", @"pt", @"ru", @"vi",
+    @"zh-Hans", @"zh-Hant",
 ];
 
 + (NSSet<NSString *> *)mapboxStreetsLanguages {

--- a/platform/darwin/test/MGLStyleTests.mm
+++ b/platform/darwin/test/MGLStyleTests.mm
@@ -457,7 +457,7 @@
     }
     {
         NSArray *preferences = @[@"zh-Hant"];
-        XCTAssertNil([MGLVectorTileSource preferredMapboxStreetsLanguageForPreferences:preferences]);
+        XCTAssertEqualObjects([MGLVectorTileSource preferredMapboxStreetsLanguageForPreferences:preferences], @"zh-Hant");
     }
     {
         NSArray *preferences = @[@"en", @"fr", @"el"];

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## master
+
+* The `-[MGLStyle localizeLabelsIntoLocale:]` and `-[NSExpression mgl_expressionLocalizedIntoLocale:]` methods can now localize text into Traditional Chinese and Vietnamese. ([#173](https://github.com/mapbox/mapbox-gl-native-ios/pull/173))
+
 ## 5.7.0 - February 13, 2020
 
 ### Bug fixes

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Setting `MGLMapView.contentInset` now moves the map’s focal point to the center of the content frame after insetting. ([#14664](https://github.com/mapbox/mapbox-gl-native/pull/14664))
 * Added the `-[MGLMapViewDelegate mapView:shouldRemoveStyleImage:]` method for optimizing style image caching. ([#14769](https://github.com/mapbox/mapbox-gl-native/pull/14769))
 * Introduce `text-writing-mode` layout property for symbol layer ([#14932](https://github.com/mapbox/mapbox-gl-native/pull/14932)). The `text-writing-mode` layout property allows control over symbol's preferred writing mode. The new property value is an array, whose values are enumeration values from a ( `horizontal` | `vertical` ) set.
+* The `-[MGLStyle localizeLabelsIntoLocale:]` and `-[NSExpression mgl_expressionLocalizedIntoLocale:]` methods can now localize text into Traditional Chinese and Vietnamese. ([#173](https://github.com/mapbox/mapbox-gl-native-ios/pull/173))
 
 ### Other changes
 


### PR DESCRIPTION
Mapbox Streets source v8.3 adds names in Traditional Chinese and Vietnamese, according to [this documentation](https://docs.mapbox.com/vector-tiles/reference/mapbox-streets-v8/#common-fields). With this change, the `-[MGLStyle localizeLabelsIntoLocale:]` and `-[NSExpression mgl_expressionLocalizedIntoLocale:]` methods can now localize text into these languages (automatically by default if the system’s Preferred Language setting is set to one of them).

Fixes #169.

/cc @mapbox/maps-ios @lukasmartinelli @jcsg @lloydsheng