### PR TITLE
Mapbox Maps SDK for iOS v5.8.0-alpha.1, macOS v0.15.0-alpha.1

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
-## master
+## 5.8.0
 
 ### Styles and rendering
 

--- a/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '5.7.0'
+  version = '5.8.0-alpha.1'
 
   m.name    = 'Mapbox-iOS-SDK-snapshot-dynamic'
   m.version = "#{version}-snapshot"

--- a/platform/ios/Mapbox-iOS-SDK-stripped.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-stripped.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '5.7.0'
+  version = '5.8.0-alpha.1'
 
   m.name    = 'Mapbox-iOS-SDK-stripped'
   m.version = "#{version}-stripped"

--- a/platform/ios/Mapbox-iOS-SDK.podspec
+++ b/platform/ios/Mapbox-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '5.7.0'
+  version = '5.8.0-alpha.1'
 
   m.name    = 'Mapbox-iOS-SDK'
   m.version = version

--- a/platform/ios/scripts/publish.sh
+++ b/platform/ios/scripts/publish.sh
@@ -18,7 +18,7 @@ else
     PUBLISH_STYLE=""
 fi
 
-GITHUB_REPO=${GITHUB_REPO:-'mapbox-gl-native'}
+GITHUB_REPO=${GITHUB_REPO:-'mapbox-gl-native-ios'}
 
 #
 # zip

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -15,7 +15,7 @@
 * Fixed crashes triggered when `MGLSource` and `MGLStyleLayer` objects are accessed after having been invalidated after a style change. ([#15539](https://github.com/mapbox/mapbox-gl-native/pull/15539))
 * Fixed an issue where fill extrusion layers would be incorrectly rendered above other layers. ([#15065](https://github.com/mapbox/mapbox-gl-native/pull/15065))
 * Fixed rendering and collision detection issues with using `MGLSymbolStyleLayer.textVariableAnchor` and `MGLSymbolStyleLayer.iconTextFit` properties on the same layer. ([#15367](https://github.com/mapbox/mapbox-gl-native/pull/15367))
-* Fixed symbol overlap when zooming out quickly. ([15416](https://github.com/mapbox/mapbox-gl-native/pull/15416))
+* Fixed symbol overlap when zooming out quickly. ([#15416](https://github.com/mapbox/mapbox-gl-native/pull/15416))
 * Fixed an issue where non-template images would draw as template images when used in the same style layer. ([#15456](https://github.com/mapbox/mapbox-gl-native/pull/15456))
 * Fixed an issue where the collision boxes for symbols would not be updated when `MGLSymbolStyleLayer.textTranslation` or `MGLSymbolStyleLayer.iconTranslation` were used. ([#15467](https://github.com/mapbox/mapbox-gl-native/pull/15467))
 * Fixed an issue that caused `MGLTileSourceOptionMaximumZoomLevel` to be ignored when setting `MGLTileSource.configurationURL`. ([#15581](https://github.com/mapbox/mapbox-gl-native/pull/15581))

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for Mapbox Maps SDK for macOS
 
-## master
+## 0.15.0
 
 ### Styles and rendering
 

--- a/platform/macos/Mapbox-macOS-SDK-symbols.podspec
+++ b/platform/macos/Mapbox-macOS-SDK-symbols.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '0.14.0'
+  version = '0.15.0-alpha.1'
 
   m.name    = 'Mapbox-macOS-SDK-symbols'
   m.version = "#{version}-symbols"

--- a/platform/macos/Mapbox-macOS-SDK.podspec
+++ b/platform/macos/Mapbox-macOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '0.14.0'
+  version = '0.15.0-alpha.1'
 
   m.name    = 'Mapbox-macOS-SDK'
   m.version = version

--- a/platform/macos/docs/pod-README.md
+++ b/platform/macos/docs/pod-README.md
@@ -8,7 +8,7 @@ Put interactive, scalable world maps into your native Cocoa application with the
 * A well-designed, fully documented API helps you stay productive.
 * Develop across [multiple platforms](https://www.mapbox.com/maps/), including [iOS](https://docs.mapbox.com/ios/maps/), using the same styles and similar APIs.
 
-![](https://raw.githubusercontent.com/mapbox/mapbox-gl-native/master/platform/macos/docs/img/screenshot.jpg)
+![](https://raw.githubusercontent.com/mapbox/mapbox-gl-native-ios/master/platform/macos/docs/img/screenshot.jpg)
 
 The Mapbox Maps SDK for macOS is compatible with macOS 10.11.0 and above for Cocoa applications developed in Objective-C, Swift, Interface Builder, or AppleScript. For hybrid applications, consider [Mapbox GL JS](https://www.mapbox.com/mapbox-gl-js/).
 

--- a/platform/macos/scripts/deploy-packages.sh
+++ b/platform/macos/scripts/deploy-packages.sh
@@ -75,7 +75,7 @@ publish() {
 }
 
 export GITHUB_USER=mapbox
-export GITHUB_REPO=mapbox-gl-native
+export GITHUB_REPO=mapbox-gl-native-ios
 export BUILDTYPE=Release
 
 VERSION_TAG=${VERSION_TAG:-''}

--- a/platform/macos/scripts/document.sh
+++ b/platform/macos/scripts/document.sh
@@ -42,7 +42,7 @@ cp -r platform/macos/docs/img "${OUTPUT}"
 jazzy \
     --config platform/macos/jazzy.yml \
     --sdk macosx \
-    --github-file-prefix https://github.com/mapbox/mapbox-gl-native/tree/${BRANCH} \
+    --github-file-prefix https://github.com/mapbox/mapbox-gl-native-ios/tree/${BRANCH} \
     --module-version ${SHORT_VERSION} \
     --readme ${README} \
     --documentation="platform/{darwin,macos}/docs/guides/*.md" \


### PR DESCRIPTION
Updated the changelogs and CocoaPods podspecs for Mapbox Maps SDK for iOS v5.8.0-alpha.1 and Mapbox Maps SDK for macOS v0.15.0-alpha.1. Also fixed up some stray references to mapbox/mapbox-gl-native in macOS scripts. (The website will remain at that repository’s GitHub Pages site for now, but links to the source code still need to work.)

Depends on #193. Retarget and rebase onto master before merging.

/cc @mapbox/maps-ios