### PR TITLE
Fix release scripts

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -303,7 +303,7 @@ jobs:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_NO_INSTALL_CLEANUP: 1
-      SLACK_CHANNEL: C0ACM9Q2C
+      SLACK_CHANNEL: CU0LHNNJY
     steps:
       - install-macos-dependencies
       - install-dependencies
@@ -330,7 +330,7 @@ jobs:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_NO_INSTALL_CLEANUP: 1
-      SLACK_CHANNEL: C0ACM9Q2C
+      SLACK_CHANNEL: CU0LHNNJY
     steps:
       - install-macos-dependencies
       - install-dependencies
@@ -350,7 +350,7 @@ jobs:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_NO_INSTALL_CLEANUP: 1
-      SLACK_CHANNEL: C0ACM9Q2C
+      SLACK_CHANNEL: CU0LHNNJY
     steps:
       - install-macos-dependencies
       - install-dependencies
@@ -370,7 +370,7 @@ jobs:
       BUILDTYPE: Debug
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_NO_INSTALL_CLEANUP: 1
-      SLACK_CHANNEL: C0ACM9Q2C
+      SLACK_CHANNEL: CU0LHNNJY
     steps:
       - install-macos-dependencies
       - install-dependencies
@@ -391,7 +391,7 @@ jobs:
       BUILDTYPE: Release
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_NO_INSTALL_CLEANUP: 1
-      SLACK_CHANNEL: C0ACM9Q2C
+      SLACK_CHANNEL: CU0LHNNJY
     steps:
       - install-macos-dependencies
       - install-dependencies
@@ -443,7 +443,7 @@ jobs:
       BUILDTYPE: Release
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_NO_INSTALL_CLEANUP: 1
-      SLACK_CHANNEL: C0ACM9Q2C
+      SLACK_CHANNEL: CU0LHNNJY
     steps:
       - checkout
       - run:

--- a/platform/macos/scripts/deploy-packages.sh
+++ b/platform/macos/scripts/deploy-packages.sh
@@ -124,7 +124,7 @@ if [[ ${#} -eq 3 &&  $3 == "-g" ]]; then
     GITHUB_RELEASE=true
 fi
 
-make clean && make distclean
+npm install --ignore-scripts
 mkdir -p ${BINARY_DIRECTORY}
 
 if [[ "${GITHUB_RELEASE}" == true ]]; then


### PR DESCRIPTION
The ios-release-tag CI workflow failed during the iOS map SDK v5.8.0-alpha.1 release process (#194). This PR disables ccache so that stale build artifacts from the previous release don’t contaminate the build. In addition, I’ve updated the Slack channel that CircleCI sends some notifications to and fixed an issue that prevented the macOS map SDK release process from running smoothly.

Depends on mapbox/mapbox-gl-native#16290.

/cc @mapbox/maps-ios