### PR TITLE
Add pr template for drafting changelogs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+`<changelog>Replace text with suggested changelog entry for this PR.</changelog>`
+
+<!-- Examples: -->
+<!-- `<changelog>Enabled newly loaded labels to appear faster on the screen.</changelog>` -->
+<!-- `<changelog>Added an option to set the minimum and maximum pitch of a `Map`.</changelog>`-->
+<!-- `<changelog>Introduced `in` expression for testing whether an item exists in an array or a substring exists in a string.</changelog>`
+<!-- `<changelog>Significantly improved offline pack download performance by marking resources as used in batches.</changelog>`
+<!-- `<changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `MGLSymbolStyleLayer.symbolSortKey`.</changelog>` -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-`<changelog>Replace text with suggested changelog entry for this PR.</changelog>`
+`<changelog>Replace text with suggested changelog entry for this PR or add the `skip changelog` label.</changelog>`
 
 <!-- Examples: -->
 <!-- `<changelog>Enabled newly loaded labels to appear faster on the screen.</changelog>` -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-`<changelog>Replace text with suggested changelog entry for this PR or add the `skip changelog` label.</changelog>`
+`<changelog>Replace text with suggested changelog entry for this PR or add the 'skip changelog' label.</changelog>`
 
 <!-- Examples: -->
 <!-- `<changelog>Enabled newly loaded labels to appear faster on the screen.</changelog>` -->


### PR DESCRIPTION
This follows the convention set forth by GL JS ([example at the bottom of this PR](https://github.com/mapbox/mapbox-gl-js/pull/9349)) which makes it compatible with [github-release-tools](https://github.com/mapbox/github-release-tools)' changelog-draft script if we set it up in the future.

cc/ @mapbox/maps-ios @1ec5 