### PR TITLE
Add options for constraining the camera’s pitch

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -16,6 +16,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ### Other changes
 
+* Added the `MGLMapView.minimumPitch` and `MGLMapView.maximumPitch` properties to further limit how much the user or your code can tilt the map. ([#208](https://github.com/mapbox/mapbox-gl-native-ios/pull/208))
 * Fixed issues where an offline pack would stop downloading before completion. ([#16230](https://github.com/mapbox/mapbox-gl-native/pull/16230), [#16240](https://github.com/mapbox/mapbox-gl-native/pull/16240))
 * When an offline pack encounters an HTTP 404 error, the `MGLOfflinePackUserInfoKeyError` user info key of the `MGLOfflinePackErrorNotification` now indicates the resource that could not be downloaded. ([#16240](https://github.com/mapbox/mapbox-gl-native/pull/16240))
 * Fixed a memory leak when zooming with any options enabled in the `MGLMapView.debugMask` property. ([#15179](https://github.com/mapbox/mapbox-gl-native/issues/15179))

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -926,6 +926,29 @@ MGL_EXPORT
 - (void)setDirection:(CLLocationDirection)direction animated:(BOOL)animated;
 
 /**
+ The minimum pitch of the map’s camera toward the horizon measured in degrees.
+
+ If the value of this property is greater than that of the `maximumPitch`
+ property, the behavior is undefined. The pitch may not be less than 0
+ regardless of this property.
+
+ The default value of this property is 0 degrees, allowing the map to appear
+ two-dimensional.
+ */
+@property (nonatomic) CGFloat minimumPitch;
+
+/**
+ The maximum pitch of the map’s camera toward the horizon measured in degrees.
+
+ If the value of this property is smaller than that of the `minimumPitch`
+ property, the behavior is undefined. The pitch may not exceed 60 degrees
+ regardless of this property.
+
+ The default value of this property is 60 degrees.
+ */
+@property (nonatomic) CGFloat maximumPitch;
+
+/**
  Resets the map rotation to a northern heading — a `direction` of `0` degrees.
  */
 - (IBAction)resetNorth;

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3526,6 +3526,28 @@ public:
     return *self.mbglMap.getBounds().maxZoom;
 }
 
+- (CGFloat)minimumPitch
+{
+    return *_mbglMap->getBounds().minPitch;
+}
+
+- (void)setMinimumPitch:(CGFloat)minimumPitch
+{
+    MGLLogDebug(@"Setting minimumPitch: %f", minimumPitch);
+    _mbglMap->setBounds(mbgl::BoundOptions().withMinPitch(minimumPitch));
+}
+
+- (CGFloat)maximumPitch
+{
+    return *_mbglMap->getBounds().maxPitch;
+}
+
+- (void)setMaximumPitch:(CGFloat)maximumPitch
+{
+    MGLLogDebug(@"Setting maximumPitch: %f", maximumPitch);
+    _mbglMap->setBounds(mbgl::BoundOptions().withMaxPitch(maximumPitch));
+}
+
 - (MGLCoordinateBounds)visibleCoordinateBounds
 {
     return [self convertRect:self.bounds toCoordinateBoundsFromView:self];

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -33,6 +33,7 @@
   * `-[MGLMapView setVisibleCoordinateBounds:edgePadding:animated:completionHandler:]`
   * `-[MGLMapView setContentInsets:animated:completionHandler:]`
   * `-[MGLMapView showAnnotations:edgePadding:animated:completionHandler:]`
+* Added the `MGLMapView.minimumPitch` and `MGLMapView.maximumPitch` properties to further limit how much the user or your code can tilt the map. ([#208](https://github.com/mapbox/mapbox-gl-native-ios/pull/208))
 * Fixed an issue where it was possible to set the map’s content insets then tilt the map enough to see the horizon, causing performance issues. ([#15195](https://github.com/mapbox/mapbox-gl-native/pull/15195))
 * Fixed an issue where animated camera transitions zoomed in or out too dramatically. ([#15281](https://github.com/mapbox/mapbox-gl-native/pull/15281))
 

--- a/platform/macos/src/MGLMapView.h
+++ b/platform/macos/src/MGLMapView.h
@@ -306,6 +306,29 @@ MGL_EXPORT IB_DESIGNABLE
 - (void)setDirection:(CLLocationDirection)direction animated:(BOOL)animated;
 
 /**
+ The minimum pitch of the map’s camera toward the horizon measured in degrees.
+
+ If the value of this property is greater than that of the `maximumPitch`
+ property, the behavior is undefined. The pitch may not be less than 0
+ regardless of this property.
+
+ The default value of this property is 0 degrees, allowing the map to appear
+ two-dimensional.
+ */
+@property (nonatomic) CGFloat minimumPitch;
+
+/**
+ The maximum pitch of the map’s camera toward the horizon measured in degrees.
+
+ If the value of this property is smaller than that of the `minimumPitch`
+ property, the behavior is undefined. The pitch may not exceed 60 degrees
+ regardless of this property.
+
+ The default value of this property is 60 degrees.
+ */
+@property (nonatomic) CGFloat maximumPitch;
+
+/**
  A camera representing the current viewpoint of the map.
  */
 @property (nonatomic, copy) MGLMapCamera *camera;

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -1175,6 +1175,24 @@ public:
     [self setDirection:*_mbglMap->getCameraOptions().bearing + delta animated:animated];
 }
 
+- (CGFloat)minimumPitch {
+    return *_mbglMap->getBounds().minPitch;
+}
+
+- (void)setMinimumPitch:(CGFloat)minimumPitch {
+    MGLLogDebug(@"Setting minimumPitch: %f", minimumPitch);
+    _mbglMap->setBounds(mbgl::BoundOptions().withMinPitch(minimumPitch));
+}
+
+- (CGFloat)maximumPitch {
+    return *_mbglMap->getBounds().maxPitch;
+}
+
+- (void)setMaximumPitch:(CGFloat)maximumPitch {
+    MGLLogDebug(@"Setting maximumPitch: %f", maximumPitch);
+    _mbglMap->setBounds(mbgl::BoundOptions().withMaxPitch(maximumPitch));
+}
+
 + (NSSet<NSString *> *)keyPathsForValuesAffectingCamera {
     return [NSSet setWithObjects:@"latitude", @"longitude", @"centerCoordinate", @"zoomLevel", @"direction", nil];
 }


### PR DESCRIPTION
Added the `MGLMapView.minimumPitch` and `MGLMapView.maximumPitch` properties to further limit how much the map can be tilted by the user using gestures or by the application programmatically.

Fixes #176.

<!-- `<changelog>Added the `MGLMapView.minimumPitch` and `MGLMapView.maximumPitch` properties to further limit how much the user or your code can tilt the map.</changelog>` -->

/cc @mapbox/maps-ios