### PR TITLE
Streamline MGLMapSnapshotter; upgrade to Mapbox GL Native v1.4.0

### DIFF
--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -327,6 +327,9 @@ global.propertyDoc = function (propertyName, property, layerType, kind) {
     let doc = property.doc.replace(/`([^`]+?)` is set to `([^`]+?)`(?: or `([^`]+?)`)?/g, function (m, peerPropertyName, propertyValue, secondPropertyValue, offset, str) {
         let otherProperty = camelizeWithLeadingLowercase(peerPropertyName);
         let otherValue = objCType(layerType, peerPropertyName) + camelize(propertyValue);
+        if (propertyValue === 'true' || propertyValue === 'false') {
+            otherValue = propertyValue === 'true' ? 'YES' : 'NO';
+        }
         if (property.type == 'array' && kind == 'light') {
             otherValue = propertyValue;
         }

--- a/platform/darwin/src/MGLMapSnapshotter.h
+++ b/platform/darwin/src/MGLMapSnapshotter.h
@@ -185,6 +185,11 @@ typedef void (^MGLMapSnapshotCompletionHandler)(MGLMapSnapshot* _Nullable snapsh
  snapshot at a time. If you need to generate multiple snapshots concurrently,
  create multiple snapshotter objects.
  
+ An `MGLMapSnapshotter` object may be deallocated before the completion handler
+ is called. To prevent this object from being deallocated prematurely, maintain
+ a strong reference to it, for example by storing it in an instance variable of
+ the class where you initialize and start the snapshotter.
+ 
  For an interactive map, use the `MGLMapView` class. Both `MGLMapSnapshotter`
  and `MGLMapView` are compatible with offline packs managed by the
  `MGLOfflineStorage` class.
@@ -203,7 +208,8 @@ typedef void (^MGLMapSnapshotCompletionHandler)(MGLMapSnapshot* _Nullable snapsh
  let options = MGLMapSnapshotOptions(styleURL: MGLStyle.satelliteStreetsStyleURL, camera: camera, size: CGSize(width: 320, height: 480))
  options.zoomLevel = 10
  
- let snapshotter = MGLMapSnapshotter(options: options)
+ // The containing class should hold a strong reference to this object.
+ snapshotter = MGLMapSnapshotter(options: options)
  snapshotter.start { (snapshot, error) in
      if let error = error {
          fatalError(error.localizedDescription)
@@ -236,6 +242,11 @@ MGL_EXPORT
 /**
  Starts the snapshot creation and executes the specified block with the result.
  
+ The snapshotter may be deallocated before the completion handler is called. To
+ prevent the snapshotter from being deallocated prematurely, maintain a strong
+ reference to it, for example by storing it in an instance variable of the class
+ where you call this method.
+ 
  @param completionHandler The block to handle the result in.
  */
 - (void)startWithCompletionHandler:(MGLMapSnapshotCompletionHandler)completionHandler;
@@ -243,6 +254,11 @@ MGL_EXPORT
 /**
  Starts the snapshot creation and executes the specified block with the result
  on the specified queue.
+ 
+ The snapshotter may be deallocated before the completion handler is called. To
+ prevent the snapshotter from being deallocated prematurely, maintain a strong
+ reference to it, for example by storing it in an instance variable of the class
+ where you call this method.
  
  @param queue The queue to handle the result on.
  @param completionHandler The block to handle the result in.
@@ -253,6 +269,12 @@ MGL_EXPORT
  Starts the snapshot creation and executes the specified blocks with the result
  on the specified queue. Use this option if you want to add custom drawing on top of the
  resulting `MGLMapSnapshot`.
+ 
+ The snapshotter may be deallocated before the completion handler is called. To
+ prevent the snapshotter from being deallocated prematurely, maintain a strong
+ reference to it, for example by storing it in an instance variable of the class
+ where you call this method.
+ 
  @param overlayHandler The block to handle manipulation of the `MGLMapSnapshotter`'s `CGContext`.
  @param completionHandler The block to handle the result in.
  */

--- a/platform/darwin/src/MGLMapSnapshotter.h
+++ b/platform/darwin/src/MGLMapSnapshotter.h
@@ -247,7 +247,8 @@ MGL_EXPORT
  reference to it, for example by storing it in an instance variable of the class
  where you call this method.
  
- @param completionHandler The block to handle the result in.
+ @param completionHandler The block to call with a finished snapshot. The block
+    is executed on the main queue.
  */
 - (void)startWithCompletionHandler:(MGLMapSnapshotCompletionHandler)completionHandler;
 
@@ -260,23 +261,29 @@ MGL_EXPORT
  reference to it, for example by storing it in an instance variable of the class
  where you call this method.
  
- @param queue The queue to handle the result on.
- @param completionHandler The block to handle the result in.
+ @param queue The queue on which to call the block specified in the
+    `completionHandler` parameter.
+ @param completionHandler The block to call with a finished snapshot. The block
+     is executed on the queue specified in the `queue` parameter.
  */
 - (void)startWithQueue:(dispatch_queue_t)queue completionHandler:(MGLMapSnapshotCompletionHandler)completionHandler;
 
 /**
  Starts the snapshot creation and executes the specified blocks with the result
- on the specified queue. Use this option if you want to add custom drawing on top of the
- resulting `MGLMapSnapshot`.
+ on the specified queue. Use this option if you want to add custom drawing on
+ top of the resulting `MGLMapSnapshot`.
  
  The snapshotter may be deallocated before the completion handler is called. To
  prevent the snapshotter from being deallocated prematurely, maintain a strong
  reference to it, for example by storing it in an instance variable of the class
  where you call this method.
  
- @param overlayHandler The block to handle manipulation of the `MGLMapSnapshotter`'s `CGContext`.
- @param completionHandler The block to handle the result in.
+ @param overlayHandler The block to call after the base map finishes drawing but
+    before certain built-in overlays draw. The block can use Core Graphics to
+    draw custom content directly over the base map. The block is executed on a
+    background queue.
+ @param completionHandler The block to call with a finished snapshot. The block
+     is executed on the main queue.
  */
 - (void)startWithOverlayHandler:(MGLMapSnapshotOverlayHandler)overlayHandler completionHandler:(MGLMapSnapshotCompletionHandler)completionHandler;
 

--- a/platform/darwin/src/MGLMapSnapshotter.h
+++ b/platform/darwin/src/MGLMapSnapshotter.h
@@ -58,7 +58,7 @@ typedef void (^MGLMapSnapshotOverlayHandler)(MGLMapSnapshotOverlay * snapshotOve
  The options to use when creating images with the `MGLMapSnapshotter`.
  */
 MGL_EXPORT
-@interface MGLMapSnapshotOptions : NSObject
+@interface MGLMapSnapshotOptions : NSObject <NSCopying>
 
 /**
  Creates a set of options with the minimum required information.
@@ -252,7 +252,7 @@ MGL_EXPORT
 /**
  Starts the snapshot creation and executes the specified blocks with the result
  on the specified queue. Use this option if you want to add custom drawing on top of the
- resulting `MGLMapSnapShot`.
+ resulting `MGLMapSnapshot`.
  @param overlayHandler The block to handle manipulation of the `MGLMapSnapshotter`'s `CGContext`.
  @param completionHandler The block to handle the result in.
  */

--- a/platform/darwin/src/MGLOfflineStorage.h
+++ b/platform/darwin/src/MGLOfflineStorage.h
@@ -376,10 +376,10 @@ MGL_EXPORT
  to `0`. Setting the maximum ambient cache size does not impact the maximum size
  of offline packs.
  
- While this method does not limit the space available to offline packs,
- data in offline packs count towards this limit. If the maximum ambient
- cache size is set to 30 MB and 20 MB of offline packs are downloaded,
- there may be only 10 MB reserved for the ambient cache.
+ This method does not limit the space available to offline packs, and data in
+ offline packs does not count towards this limit. If you set the maximum ambient
+ cache size to 30 MB then download 20 MB of offline packs, 30 MB will remain
+ available for the ambient cache.
  
  This method should be called before the map and map style have been loaded.
  

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -1057,10 +1057,12 @@ MGL_EXPORT
 @property (nonatomic, null_resettable) NSExpression *symbolPlacement;
 
 /**
- Sorts features in ascending order based on this value. Features with a higher
- sort key will appear above features with a lower sort key when they overlap.
- Features with a lower sort key will have priority over other features when
- doing placement.
+ Sorts features in ascending order based on this value. Features with lower sort
+ keys are drawn and placed first.  When `iconAllowsOverlap` or
+ `textAllowsOverlap` is `false`, features with a lower sort key will have
+ priority during placement. When `iconAllowsOverlap` or `textAllowsOverlap` is
+ set to `YES`, features with a higher sort key will overlap over features with a
+ lower sort key.
  
  You can set this property to an expression containing any of the following:
  

--- a/platform/darwin/test/MGLDocumentationExampleTests.swift
+++ b/platform/darwin/test/MGLDocumentationExampleTests.swift
@@ -463,13 +463,15 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
             }
         }
 
+        let snapshotter: MGLMapSnapshotter
         //#-example-code
         let camera = MGLMapCamera(lookingAtCenter: CLLocationCoordinate2D(latitude: 37.7184, longitude: -122.4365), altitude: 100, pitch: 20, heading: 0)
 
         let options = MGLMapSnapshotOptions(styleURL: MGLStyle.satelliteStreetsStyleURL, camera: camera, size: CGSize(width: 320, height: 480))
         options.zoomLevel = 10
 
-        let snapshotter = MGLMapSnapshotter(options: options)
+        // The containing class should hold a strong reference to this object.
+        snapshotter = MGLMapSnapshotter(options: options)
         snapshotter.start { (snapshot, error) in
             if let error = error {
                 fatalError(error.localizedDescription)

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -19,6 +19,8 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Added the `MGLMapView.minimumPitch` and `MGLMapView.maximumPitch` properties to further limit how much the user or your code can tilt the map. ([#208](https://github.com/mapbox/mapbox-gl-native-ios/pull/208))
 * Fixed issues where an offline pack would stop downloading before completion. ([#16230](https://github.com/mapbox/mapbox-gl-native/pull/16230), [#16240](https://github.com/mapbox/mapbox-gl-native/pull/16240))
 * When an offline pack encounters an HTTP 404 error, the `MGLOfflinePackUserInfoKeyError` user info key of the `MGLOfflinePackErrorNotification` now indicates the resource that could not be downloaded. ([#16240](https://github.com/mapbox/mapbox-gl-native/pull/16240))
+* The `-[MGLMapSnapshotter cancel]` method no longer calls the completion handler passed into `-[MGLMapSnapshotter startWithCompletionHandler:]`. ([#209](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
+* Fixed an issue where the `MGLMapSnapshotter.loading` property always returned `NO`, even while loading a snapshot. ([#209](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
 * Fixed a memory leak when zooming with any options enabled in the `MGLMapView.debugMask` property. ([#15179](https://github.com/mapbox/mapbox-gl-native/issues/15179))
 * Added the `-[MGLOfflineStorage preloadData:forURL:modificationDate:expirationDate:eTag:mustRevalidate:completionHandler:]` method for determining when the data is ready to retrieve from the cache. ([#188](https://github.com/mapbox/mapbox-gl-native-ios/pull/188))
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -14,13 +14,18 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed an issue where an `MGLSymbolStyleLayer.lineDashPattern` value of `{1, 0}` resulted in hairline gaps. ([#16202](https://github.com/mapbox/mapbox-gl-native/pull/16202))
 * Improved the performance of loading a style that has many style images. ([#16187](https://github.com/mapbox/mapbox-gl-native/pull/16187))
 
+### Networking and storage
+
+* Downloaded offline packs no longer reduce the storage space available for ambient caching of tiles and other resources. ([#15622](https://github.com/mapbox/mapbox-gl-native/pull/15622))
+* Fixed issues where an offline pack would stop downloading before completion. ([#16230](https://github.com/mapbox/mapbox-gl-native/pull/16230), [#16240](https://github.com/mapbox/mapbox-gl-native/pull/16240))
+* When an offline pack encounters an HTTP 404 error, the `MGLOfflinePackUserInfoKeyError` user info key of the `MGLOfflinePackErrorNotification` now indicates the resource that could not be downloaded. ([#16240](https://github.com/mapbox/mapbox-gl-native/pull/16240))
+
 ### Other changes
 
 * Added the `MGLMapView.minimumPitch` and `MGLMapView.maximumPitch` properties to further limit how much the user or your code can tilt the map. ([#208](https://github.com/mapbox/mapbox-gl-native-ios/pull/208))
-* Fixed issues where an offline pack would stop downloading before completion. ([#16230](https://github.com/mapbox/mapbox-gl-native/pull/16230), [#16240](https://github.com/mapbox/mapbox-gl-native/pull/16240))
-* When an offline pack encounters an HTTP 404 error, the `MGLOfflinePackUserInfoKeyError` user info key of the `MGLOfflinePackErrorNotification` now indicates the resource that could not be downloaded. ([#16240](https://github.com/mapbox/mapbox-gl-native/pull/16240))
 * The `-[MGLMapSnapshotter cancel]` method no longer calls the completion handler passed into `-[MGLMapSnapshotter startWithCompletionHandler:]`. ([#209](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
 * Fixed an issue where the `MGLMapSnapshotter.loading` property always returned `NO`, even while loading a snapshot. ([#209](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
+* Improved performance when continuously animating a tilted map. ([#16287](https://github.com/mapbox/mapbox-gl-native/pull/16287))
 * Fixed a memory leak when zooming with any options enabled in the `MGLMapView.debugMask` property. ([#15179](https://github.com/mapbox/mapbox-gl-native/issues/15179))
 * Added the `-[MGLOfflineStorage preloadData:forURL:modificationDate:expirationDate:eTag:mustRevalidate:completionHandler:]` method for determining when the data is ready to retrieve from the cache. ([#188](https://github.com/mapbox/mapbox-gl-native-ios/pull/188))
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -14,6 +14,12 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed an issue where an `MGLSymbolStyleLayer.lineDashPattern` value of `{1, 0}` resulted in hairline gaps. ([#16202](https://github.com/mapbox/mapbox-gl-native/pull/16202))
 * Improved the performance of loading a style that has many style images. ([#16187](https://github.com/mapbox/mapbox-gl-native/pull/16187))
 
+### Snapshots
+
+* `MGLMapSnapshotter` no longer keeps itself from being deallocated before its completion handler is called. To ensure that the completion handler passed into `-[MGLMapSnapshotter startWithCompletionHandler:]` is called, maintain a strong reference to the snapshotter from a longer-lived class, such as the class where you call `-[MGLMapSnapshotter startWithCompletionHandler:]`. ([#210](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
+* The `-[MGLMapSnapshotter cancel]` method no longer calls the completion handler passed into `-[MGLMapSnapshotter startWithCompletionHandler:]`. ([#210](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
+* Fixed an issue where the `MGLMapSnapshotter.loading` property always returned `NO`, even while loading a snapshot. ([#210](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
+
 ### Networking and storage
 
 * Downloaded offline packs no longer reduce the storage space available for ambient caching of tiles and other resources. ([#15622](https://github.com/mapbox/mapbox-gl-native/pull/15622))
@@ -23,8 +29,6 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 ### Other changes
 
 * Added the `MGLMapView.minimumPitch` and `MGLMapView.maximumPitch` properties to further limit how much the user or your code can tilt the map. ([#208](https://github.com/mapbox/mapbox-gl-native-ios/pull/208))
-* The `-[MGLMapSnapshotter cancel]` method no longer calls the completion handler passed into `-[MGLMapSnapshotter startWithCompletionHandler:]`. ([#209](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
-* Fixed an issue where the `MGLMapSnapshotter.loading` property always returned `NO`, even while loading a snapshot. ([#209](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
 * Improved performance when continuously animating a tilted map. ([#16287](https://github.com/mapbox/mapbox-gl-native/pull/16287))
 * Fixed a memory leak when zooming with any options enabled in the `MGLMapView.debugMask` property. ([#15179](https://github.com/mapbox/mapbox-gl-native/issues/15179))
 * Added the `-[MGLOfflineStorage preloadData:forURL:modificationDate:expirationDate:eTag:mustRevalidate:completionHandler:]` method for determining when the data is ready to retrieve from the cache. ([#188](https://github.com/mapbox/mapbox-gl-native-ios/pull/188))

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Added the `MGLMapView.minimumPitch` and `MGLMapView.maximumPitch` properties to further limit how much the user or your code can tilt the map. ([#208](https://github.com/mapbox/mapbox-gl-native-ios/pull/208))
 * Fixed an issue where it was possible to set the map’s content insets then tilt the map enough to see the horizon, causing performance issues. ([#15195](https://github.com/mapbox/mapbox-gl-native/pull/15195))
 * Fixed an issue where animated camera transitions zoomed in or out too dramatically. ([#15281](https://github.com/mapbox/mapbox-gl-native/pull/15281))
+* Improved performance when continuously animating a tilted map. ([#16287](https://github.com/mapbox/mapbox-gl-native/pull/16287))
 
 ### Feature querying
 
@@ -52,6 +53,7 @@
 ### Networking and storage
 
 * Ideographic glyphs from Chinese, Japanese, and Korean are no longer downloaded by default as part of offline packs; they are instead rendered on-device, saving bandwidth and storage while improving performance. ([#14176](https://github.com/mapbox/mapbox-gl-native/pull/14176))
+* Downloaded offline packs no longer reduce the storage space available for ambient caching of tiles and other resources. ([#15622](https://github.com/mapbox/mapbox-gl-native/pull/15622))
 * Added the `MGLMapView.prefetchesTiles` property to configure lower-resolution tile prefetching behavior. ([#14816](https://github.com/mapbox/mapbox-gl-native/pull/14816))
 * Fixed a crash when `-[MGLOfflinePack invalidate]` is called on different threads. ([#15582](https://github.com/mapbox/mapbox-gl-native/pull/15582))
 * Fixed issues where an offline pack would stop downloading before completion. ([#16230](https://github.com/mapbox/mapbox-gl-native/pull/16230), [#16240](https://github.com/mapbox/mapbox-gl-native/pull/16240))

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -47,8 +47,9 @@
 ### Snapshots
 
 * Added an `-[MGLMapSnapshotter startWithOverlayHandler:completionHandler:]` method to provide the snapshot's current `CGContext` in order to perform custom drawing on `MGLMapSnapshot` objects. ([#15530](https://github.com/mapbox/mapbox-gl-native/pull/15530))
-* The `-[MGLMapSnapshotter cancel]` method no longer calls the completion handler passed into `-[MGLMapSnapshotter startWithCompletionHandler:]`. ([#209](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
-* Fixed an issue where the `MGLMapSnapshotter.loading` property always returned `NO`, even while loading a snapshot. ([#209](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
+* `MGLMapSnapshotter` no longer keeps itself from being deallocated before its completion handler is called. To ensure that the completion handler passed into `-[MGLMapSnapshotter startWithCompletionHandler:]` is called, maintain a strong reference to the snapshotter from a longer-lived class, such as the class where you call `-[MGLMapSnapshotter startWithCompletionHandler:]`. ([#210](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
+* The `-[MGLMapSnapshotter cancel]` method no longer calls the completion handler passed into `-[MGLMapSnapshotter startWithCompletionHandler:]`. ([#210](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
+* Fixed an issue where the `MGLMapSnapshotter.loading` property always returned `NO`, even while loading a snapshot. ([#210](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
 
 ### Networking and storage
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -43,6 +43,12 @@
 * Fixed an issue where `-[MGLMapView visibleFeaturesInRect:]` and `-[MGLShapeSource featuresMatchingPredicate:]` could return incorrect coordinates at zoom levels 20 and higher. ([#15560](https://github.com/mapbox/mapbox-gl-native/pull/15560))
 * Improved feature querying performance. ([#14930](https://github.com/mapbox/mapbox-gl-native/pull/14930))
 
+### Snapshots
+
+* Added an `-[MGLMapSnapshotter startWithOverlayHandler:completionHandler:]` method to provide the snapshot's current `CGContext` in order to perform custom drawing on `MGLMapSnapshot` objects. ([#15530](https://github.com/mapbox/mapbox-gl-native/pull/15530))
+* The `-[MGLMapSnapshotter cancel]` method no longer calls the completion handler passed into `-[MGLMapSnapshotter startWithCompletionHandler:]`. ([#209](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
+* Fixed an issue where the `MGLMapSnapshotter.loading` property always returned `NO`, even while loading a snapshot. ([#209](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
+
 ### Networking and storage
 
 * Ideographic glyphs from Chinese, Japanese, and Korean are no longer downloaded by default as part of offline packs; they are instead rendered on-device, saving bandwidth and storage while improving performance. ([#14176](https://github.com/mapbox/mapbox-gl-native/pull/14176))
@@ -55,7 +61,6 @@
 
 ### Other changes
 
-* Added an `-[MGLMapSnapshotter startWithOverlayHandler:completionHandler:]` method to provide the snapshot's current `CGContext` in order to perform custom drawing on `MGLMapSnapshot` objects. ([#15530](https://github.com/mapbox/mapbox-gl-native/pull/15530))
 * Fixed a memory leak when zooming with any options enabled in the `MGLMapView.debugMask` property. ([#15179](https://github.com/mapbox/mapbox-gl-native/issues/15179))
 * `MGLLoggingLevel` has been updated to better match core log levels. You can now use `MGLLoggingConfiguration.loggingLevel` to filter logs from core. ([#15120](https://github.com/mapbox/mapbox-gl-native/pull/15120))
 


### PR DESCRIPTION
Upgraded MGLMapSnapshotter to be compatible with [mbgl v1.4.0](https://github.com/mapbox/mapbox-gl-native/releases/tag/maps-v1.4.0). For the iOS map SDK v5.8.0-beta.1 and macOS map SDK v0.15.0-beta.1 release notes, we’ll add:

* `MGLMapSnapshotter` no longer keeps itself from being deallocated before its completion handler is called. To ensure that the completion handler passed into `-[MGLMapSnapshotter startWithCompletionHandler:]` is called, maintain a strong reference to the snapshotter from a longer-lived class, such as the class where you call `-[MGLMapSnapshotter startWithCompletionHandler:]`. (#210)
* The `-[MGLMapSnapshotter cancel]` method no longer calls the completion handler passed into `-[MGLMapSnapshotter startWithCompletionHandler:]`. (#210)
* Fixed an issue where the `MGLMapSnapshotter.loading` property always returned `NO`, even while loading a snapshot. (#210)
* Downloaded offline packs no longer reduce the storage space available for ambient caching of tiles and other resources. (mapbox/mapbox-gl-native#15622)
* Improved performance when continuously animating a tilted map. (mapbox/mapbox-gl-native#16287)

Converted as many of MGLMapSnapshotter’s instance variables and properties as possible into local variables close to the point of use. `-loading` once again works and is used to avoid concurrent requests, now that the completion handler is no longer memoized. Snapshotter options are converted into an `mbgl::MapSnapshotter` on demand as late as possible.

The completion handler of `-startWithCompletionHandler:` and its variants is no longer called as part of `-cancel`, when the snapshotter is deallocated, or when the application is terminating, per the rationale in https://github.com/mapbox/mapbox-gl-native-ios/issues/200#issuecomment-598458116. To ensure that the snapshotter runs to completion, it is necessary to hold a strong reference to the snapshotter, ideally in the containing class.

Pushed some drawing and completion code up from inner completion blocks to outer completion blocks to avoid excessively passing state around. Converted a few class methods into standalone C functions to emphasize the avoidance of captured state.

More to come:

* [x] Upgrade mbgl to master
* [x] Regenerate runtime styling documentation
* [x] Update snapshotter to build against latest mbgl
* [x] Eliminate most snapshotter ivars
* [x] Simplify callbacks
* [ ] Keep snapshotter alive while loading as with MKMapSnapshotter (#211)
* [x] Alternatively, document the need to store a strong reference to the snapshotter in the containing class (would be undone by #211)
* [ ] Document the default completion handler queue

Fixes #209. Undoes much of mapbox/mapbox-gl-native#12355. Depends on mapbox/mapbox-gl-native#16268. Working towards #200.

<!-- `<changelog>The `-[MGLMapSnapshotter cancel]` method no longer calls the completion handler passed into `-[MGLMapSnapshotter startWithCompletionHandler:]`.</changelog>`
`<changelog>Fixed an issue where the `MGLMapSnapshotter.loading` property always returned `NO`, even while loading a snapshot.</changelog>` -->

/cc @mapbox/maps-ios @alexshalamov