### PR TITLE
Keep MGLMapSnapshotter alive through completion

### DIFF
--- a/platform/darwin/src/MGLMapSnapshotter.h
+++ b/platform/darwin/src/MGLMapSnapshotter.h
@@ -185,11 +185,6 @@ typedef void (^MGLMapSnapshotCompletionHandler)(MGLMapSnapshot* _Nullable snapsh
  snapshot at a time. If you need to generate multiple snapshots concurrently,
  create multiple snapshotter objects.
  
- An `MGLMapSnapshotter` object may be deallocated before the completion handler
- is called. To prevent this object from being deallocated prematurely, maintain
- a strong reference to it, for example by storing it in an instance variable of
- the class where you initialize and start the snapshotter.
- 
  For an interactive map, use the `MGLMapView` class. Both `MGLMapSnapshotter`
  and `MGLMapView` are compatible with offline packs managed by the
  `MGLOfflineStorage` class.
@@ -208,8 +203,7 @@ typedef void (^MGLMapSnapshotCompletionHandler)(MGLMapSnapshot* _Nullable snapsh
  let options = MGLMapSnapshotOptions(styleURL: MGLStyle.satelliteStreetsStyleURL, camera: camera, size: CGSize(width: 320, height: 480))
  options.zoomLevel = 10
  
- // The containing class should hold a strong reference to this object.
- snapshotter = MGLMapSnapshotter(options: options)
+ let snapshotter = MGLMapSnapshotter(options: options)
  snapshotter.start { (snapshot, error) in
      if let error = error {
          fatalError(error.localizedDescription)
@@ -242,11 +236,6 @@ MGL_EXPORT
 /**
  Starts the snapshot creation and executes the specified block with the result.
  
- The snapshotter may be deallocated before the completion handler is called. To
- prevent the snapshotter from being deallocated prematurely, maintain a strong
- reference to it, for example by storing it in an instance variable of the class
- where you call this method.
- 
  @param completionHandler The block to call with a finished snapshot. The block
     is executed on the main queue.
  */
@@ -255,11 +244,6 @@ MGL_EXPORT
 /**
  Starts the snapshot creation and executes the specified block with the result
  on the specified queue.
- 
- The snapshotter may be deallocated before the completion handler is called. To
- prevent the snapshotter from being deallocated prematurely, maintain a strong
- reference to it, for example by storing it in an instance variable of the class
- where you call this method.
  
  @param queue The queue on which to call the block specified in the
     `completionHandler` parameter.
@@ -272,11 +256,6 @@ MGL_EXPORT
  Starts the snapshot creation and executes the specified blocks with the result
  on the specified queue. Use this option if you want to add custom drawing on
  top of the resulting `MGLMapSnapshot`.
- 
- The snapshotter may be deallocated before the completion handler is called. To
- prevent the snapshotter from being deallocated prematurely, maintain a strong
- reference to it, for example by storing it in an instance variable of the class
- where you call this method.
  
  @param overlayHandler The block to call after the base map finishes drawing but
     before certain built-in overlays draw. The block can use Core Graphics to

--- a/platform/darwin/test/MGLDocumentationExampleTests.swift
+++ b/platform/darwin/test/MGLDocumentationExampleTests.swift
@@ -463,15 +463,13 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
             }
         }
 
-        let snapshotter: MGLMapSnapshotter
         //#-example-code
         let camera = MGLMapCamera(lookingAtCenter: CLLocationCoordinate2D(latitude: 37.7184, longitude: -122.4365), altitude: 100, pitch: 20, heading: 0)
 
         let options = MGLMapSnapshotOptions(styleURL: MGLStyle.satelliteStreetsStyleURL, camera: camera, size: CGSize(width: 320, height: 480))
         options.zoomLevel = 10
 
-        // The containing class should hold a strong reference to this object.
-        snapshotter = MGLMapSnapshotter(options: options)
+        let snapshotter = MGLMapSnapshotter(options: options)
         snapshotter.start { (snapshot, error) in
             if let error = error {
                 fatalError(error.localizedDescription)

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -16,7 +16,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ### Snapshots
 
-* `MGLMapSnapshotter` no longer keeps itself from being deallocated before its completion handler is called. To ensure that the completion handler passed into `-[MGLMapSnapshotter startWithCompletionHandler:]` is called, maintain a strong reference to the snapshotter from a longer-lived class, such as the class where you call `-[MGLMapSnapshotter startWithCompletionHandler:]`. ([#210](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
+* You no longer need to explicitly capture the `MGLMapSnapshotter` object in the completion handler that you specify in `-[MGLMapSnapshotter startWithCompletionHandler:]`. Even if you declare the snapshotter locally without holding a strong reference to it, the snapshotter is only deallocated after the completion handler finishes, and the completion handler generally receives a valid snapshot. ([#210](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
 * The `-[MGLMapSnapshotter cancel]` method no longer calls the completion handler passed into `-[MGLMapSnapshotter startWithCompletionHandler:]`. ([#210](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
 * Fixed an issue where the `MGLMapSnapshotter.loading` property always returned `NO`, even while loading a snapshot. ([#210](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
 

--- a/platform/ios/Integration Tests/Snapshotter Tests/MGLMapSnapshotterTest.m
+++ b/platform/ios/Integration Tests/Snapshotter Tests/MGLMapSnapshotterTest.m
@@ -104,8 +104,7 @@ MGLMapSnapshotter* snapshotterWithBounds(MGLCoordinateBounds bounds, CGSize size
     CLLocationCoordinate2D coord   = CLLocationCoordinate2DMake(30.0, 30.0);
 
     // Test triggering to main queue
-    dispatch_queue_t backgroundQueue = dispatch_get_main_queue();
-//  dispatch_queue_t backgroundQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+    dispatch_queue_t backgroundQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 
     __weak __typeof__(self) weakself = self;
     __block __weak MGLMapSnapshotter *weakSnapshotter;
@@ -154,8 +153,7 @@ MGLMapSnapshotter* snapshotterWithBounds(MGLCoordinateBounds bounds, CGSize size
     CLLocationCoordinate2D coord   = CLLocationCoordinate2DMake(30.0, 30.0);
 
     // Test triggering to main queue
-    dispatch_queue_t backgroundQueue = dispatch_get_main_queue();
-    //  dispatch_queue_t backgroundQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+    dispatch_queue_t backgroundQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 
     __weak __typeof__(self) weakself = self;
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -47,7 +47,7 @@
 ### Snapshots
 
 * Added an `-[MGLMapSnapshotter startWithOverlayHandler:completionHandler:]` method to provide the snapshot's current `CGContext` in order to perform custom drawing on `MGLMapSnapshot` objects. ([#15530](https://github.com/mapbox/mapbox-gl-native/pull/15530))
-* `MGLMapSnapshotter` no longer keeps itself from being deallocated before its completion handler is called. To ensure that the completion handler passed into `-[MGLMapSnapshotter startWithCompletionHandler:]` is called, maintain a strong reference to the snapshotter from a longer-lived class, such as the class where you call `-[MGLMapSnapshotter startWithCompletionHandler:]`. ([#210](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
+* You no longer need to explicitly capture the `MGLMapSnapshotter` object in the completion handler that you specify in `-[MGLMapSnapshotter startWithCompletionHandler:]`. Even if you declare the snapshotter locally without holding a strong reference to it, the snapshotter is only deallocated after the completion handler finishes, and the completion handler generally receives a valid snapshot. ([#210](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
 * The `-[MGLMapSnapshotter cancel]` method no longer calls the completion handler passed into `-[MGLMapSnapshotter startWithCompletionHandler:]`. ([#210](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
 * Fixed an issue where the `MGLMapSnapshotter.loading` property always returned `NO`, even while loading a snapshot. ([#210](https://github.com/mapbox/mapbox-gl-native-ios/pull/210))
 


### PR DESCRIPTION
Strongly capture MGLMapSnapshotter until its completion handler finishes executing. The developer no longer needs to explicitly capture the snapshotter in the completion handler to prevent it from being canceled or deallocated, because the internal completion handler does so for the developer.

Before #210, a snapshotter that wasn’t captured in its completion handler would be deallocated as soon as it went out of scope, but the completion handler would be called with an error “headlessly” after the snapshotter got deallocated. As of #210, the same snapshotter would’ve silently gone away without calling the completion handler, since it was considered the responsibility of the developer to hang onto the snapshotter. As of this PR, the developer is no longer required to hang onto the snapshotter, and the completion handler will generally receive a snapshot rather than an error.

This new behavior matches MapKit’s MKMapSnapshotter and is ideal for one-off usage. I had shied away from it in https://github.com/mapbox/mapbox-gl-native-ios/issues/200#issuecomment-598500827 because of the complexity around keeping the completion handler alive, but #210 gives us more confidence about the control flow and lifetime of any captured state. Nonetheless, this PR needs extra scrutiny because it possibly reintroduces edge cases that #210 had eliminated by reducing the snapshotter’s scope. In particular, we should make sure the application can reliably terminate while snapshotters are active without crashing.

Depends on #210. Fixes mapbox/mapbox-gl-native#12336 in a different way.

<!-- `<changelog>You no longer need to explicitly capture the `MGLMapSnapshotter` object in the completion handler that you specify in `-[MGLMapSnapshotter startWithCompletionHandler:]`. Even if you declare the snapshotter locally without holding a strong reference to it, the snapshotter is only deallocated after the completion handler finishes, and the completion handler generally receives a valid snapshot.</changelog>` -->

/cc @mapbox/maps-ios @alexshalamov