### PR TITLE
Reduce MapboxMobileEvents link time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ ifeq ($(shell uname -s), Darwin)
   HOST_PLATFORM = macos
   HOST_PLATFORM_VERSION = $(shell uname -m)
   export NINJA = platform/macos/ninja
-  export JOBS ?= $(shell sysctl -n hw.ncpu)
+  export NCPU := $(shell sysctl -n hw.ncpu)
+  export JOBS ?= $(shell expr $(NCPU) - 1)
 else ifeq ($(shell uname -s), Linux)
   HOST_PLATFORM = linux
   HOST_PLATFORM_VERSION = $(shell uname -m)


### PR DESCRIPTION
Limited the number of concurrent jobs when building the SDK to one less than the number of cores, in order to avoid the long link times seen most commonly in release builds.

Thanks to @julianrex for coming up with this potential fix for #197.

/cc @mapbox/maps-ios