### PR TITLE
Add triage label to new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/darwin.md
+++ b/.github/ISSUE_TEMPLATE/darwin.md
@@ -1,7 +1,7 @@
 ---
 name: iOS or macOS
 about: Mapbox Maps SDK for iOS or macOS
-
+labels: triage
 ---
 <!--
 Hello and thanks for contributing to the Mapbox Maps SDKs for iOS and macOS! To help us diagnose your problem quickly, please:

--- a/.github/ISSUE_TEMPLATE/darwin.md
+++ b/.github/ISSUE_TEMPLATE/darwin.md
@@ -1,7 +1,7 @@
 ---
 name: iOS or macOS
 about: Mapbox Maps SDK for iOS or macOS
-labels: triage
+labels: "status: triage"
 ---
 <!--
 Hello and thanks for contributing to the Mapbox Maps SDKs for iOS and macOS! To help us diagnose your problem quickly, please:

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,7 +1,7 @@
 ---
 name: Other
 about: CI or other non-platform specific issues
-
+labels: triage
 ---
 <!--
 Hello and thanks for contributing to the Mapbox Maps SDK! To help us diagnose your problem quickly, please:

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,7 +1,7 @@
 ---
 name: Other
 about: CI or other non-platform specific issues
-labels: triage
+labels: "status: triage"
 ---
 <!--
 Hello and thanks for contributing to the Mapbox Maps SDK! To help us diagnose your problem quickly, please:


### PR DESCRIPTION
Follow-up to a voice conversation with @julianrex.

Adds the `status: triage` label to issues by default to help us track issue status.

cc @julianrex @knov 