### PR TITLE
Resume thread in MGLOfflineStorage::unpauseFileSource

### DIFF
--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -91,8 +91,8 @@ const MGLExceptionName MGLUnsupportedRegionTypeException = @"MGLUnsupportedRegio
         return;
     }
 
-    _mbglOnlineFileSource->pause();
-    _mbglDatabaseFileSource->pause();
+    _mbglOnlineFileSource->resume();
+    _mbglDatabaseFileSource->resume();
     self.paused = NO;
 }
 #endif


### PR DESCRIPTION
`<changelog>Fixes pause/resume bug introduced in https://github.com/mapbox/mapbox-gl-native-ios/pull/188</changelog>`
