### PR TITLE
Fix compilation warnings when compiling tests in release.

### DIFF
--- a/platform/darwin/test/MGLTestAssertionHandler.m
+++ b/platform/darwin/test/MGLTestAssertionHandler.m
@@ -35,9 +35,9 @@
                                        );
     }
     else {
-        NSLog(@"Assertion Failure: %@:%lu: %@ - %@",
+        NSLog(@"Assertion Failure: %@:%ld: %@ - %@",
               fileName,
-              line,
+              (long)line,
               condition,
               description);
     }
@@ -66,9 +66,9 @@
                                        description);
     }
     else {
-        NSLog(@"Assertion Failure: %@:%lu: %@ - %@",
+        NSLog(@"Assertion Failure: %@:%ld: %@ - %@",
               fileName,
-              line,
+              (long)line,
               condition,
               description);
     }

--- a/platform/ios/Integration Tests/Annotation Tests/MGLAnnotationViewIntegrationTests.mm
+++ b/platform/ios/Integration Tests/Annotation Tests/MGLAnnotationViewIntegrationTests.mm
@@ -367,7 +367,7 @@ static const CGPoint kAnnotationRelativeScale = { 0.05f, 0.125f };
 
         //  Coord                   showsCallout  impl margins?   moveIntoView    expectMapToPan    calloutOnScreen
         {   {offset, 0.5f},         YES,          YES,            YES,            YES,              YES },
-        {   {1.0 - offset, 0.5f},   YES,          YES,            YES,            YES,              YES },
+        {   {(CGFloat)(1.0 - offset), 0.5f},   YES,          YES,            YES,            YES,              YES },
 
         PAN_TEST_TERMINATOR
     };

--- a/platform/ios/Integration Tests/MGLMapViewPendingBlockTests.m
+++ b/platform/ios/Integration Tests/MGLMapViewPendingBlockTests.m
@@ -328,7 +328,7 @@
     // Observes changes to pendingCompletionBlocks (including additions)
     self.observation = ^(NSDictionary *change){
 
-        NSLog(@"change = %@ count = %lu", change, myself.mapView.pendingCompletionBlocks.count);
+        NSLog(@"change = %@ count = %lu", change, (unsigned long)myself.mapView.pendingCompletionBlocks.count);
 
         NSArray *value = change[NSKeyValueChangeNewKey];
         


### PR DESCRIPTION
Fixes compilation warnings when building tests with Release configuration.
(Noticed during testing of https://github.com/mapbox/mapbox-gl-native-ios/pull/228)