### PR TITLE
Mapbox Maps SDK for iOS v5.8.0-beta.2, macOS v0.15.0-beta.2

### DIFF
--- a/platform/darwin/test/MGLMapSnapshotterTests.m
+++ b/platform/darwin/test/MGLMapSnapshotterTests.m
@@ -115,7 +115,7 @@ MGLImage *MGLImageFromCurrentContext() {
         }
         [completionExpectation fulfill];
     }];
-    [self waitForExpectations:@[self.styleLoadingExpectation, overlayExpectation, completionExpectation] timeout:2 enforceOrder:YES];
+    [self waitForExpectations:@[self.styleLoadingExpectation, overlayExpectation, completionExpectation] timeout:5 enforceOrder:YES];
 }
 
 - (void)testDelegate {
@@ -138,7 +138,7 @@ MGLImage *MGLImageFromCurrentContext() {
         }
         [completionExpectation fulfill];
     }];
-    [self waitForExpectations:@[self.styleLoadingExpectation, completionExpectation] timeout:2 enforceOrder:YES];
+    [self waitForExpectations:@[self.styleLoadingExpectation, completionExpectation] timeout:5 enforceOrder:YES];
 }
 
 - (void)testRuntimeStyling {
@@ -192,7 +192,7 @@ MGLImage *MGLImageFromCurrentContext() {
         }
         [completionExpectation fulfill];
     }];
-    [self waitForExpectations:@[self.styleLoadingExpectation, overlayExpectation, completionExpectation] timeout:2 enforceOrder:YES];
+    [self waitForExpectations:@[self.styleLoadingExpectation, overlayExpectation, completionExpectation] timeout:5 enforceOrder:YES];
     self.runtimeStylingActions = nil;
 }
 

--- a/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '5.8.0-beta.1'
+  version = '5.8.0-beta.2'
 
   m.name    = 'Mapbox-iOS-SDK-snapshot-dynamic'
   m.version = "#{version}-snapshot"

--- a/platform/ios/Mapbox-iOS-SDK-stripped.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-stripped.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '5.8.0-beta.1'
+  version = '5.8.0-beta.2'
 
   m.name    = 'Mapbox-iOS-SDK-stripped'
   m.version = "#{version}-stripped"

--- a/platform/ios/Mapbox-iOS-SDK.podspec
+++ b/platform/ios/Mapbox-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '5.8.0-beta.1'
+  version = '5.8.0-beta.2'
 
   m.name    = 'Mapbox-iOS-SDK'
   m.version = version

--- a/platform/macos/Mapbox-macOS-SDK-symbols.podspec
+++ b/platform/macos/Mapbox-macOS-SDK-symbols.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '0.15.0-beta.1'
+  version = '0.15.0-beta.2'
 
   m.name    = 'Mapbox-macOS-SDK-symbols'
   m.version = "#{version}-symbols"

--- a/platform/macos/Mapbox-macOS-SDK.podspec
+++ b/platform/macos/Mapbox-macOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '0.15.0-beta.1'
+  version = '0.15.0-beta.2'
 
   m.name    = 'Mapbox-macOS-SDK'
   m.version = version


### PR DESCRIPTION
Updated the CocoaPods podspecs for Mapbox Maps SDK for iOS v5.8.0-beta.2 and Mapbox Maps SDK for macOS v0.15.0-beta.2.

/cc @mapbox/maps-ios