### PR TITLE
Fix an issue that the heading indicator does not rotate if Settings > Privacy > Location Services > System Services > Compass Calibration is off

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -31,6 +31,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Added the `MGLMapView.minimumPitch` and `MGLMapView.maximumPitch` properties to further limit how much the user or your code can tilt the map. ([#208](https://github.com/mapbox/mapbox-gl-native-ios/pull/208))
 * Fixed a crash while quitting the application after adding an annotation to `MGLMapView`. ([#252](https://github.com/mapbox/mapbox-gl-native-ios/pull/252))
+* Fixed an issue where the user location annotation view’s heading indicator did not rotate if Compass Calibration was disabled in the device’s Location Services settings. ([#247](https://github.com/mapbox/mapbox-gl-native-ios/pull/247))
 * Improved performance when continuously animating a tilted map. ([#16287](https://github.com/mapbox/mapbox-gl-native/pull/16287))
 * Fixed a memory leak when zooming with any options enabled in the `MGLMapView.debugMask` property. ([#15179](https://github.com/mapbox/mapbox-gl-native/issues/15179))
 

--- a/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
+++ b/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
@@ -267,9 +267,10 @@ const CGFloat MGLUserLocationHeadingUpdateThreshold = 0.01;
             _oldHeadingAccuracy = headingAccuracy;
         }
 
-        if (self.userLocation.heading.trueHeading >= 0)
+        CLLocationDirection headingDirection = (self.userLocation.heading.trueHeading >= 0 ? self.userLocation.heading.trueHeading : self.userLocation.heading.magneticHeading);
+        if (headingDirection >= 0)
         {
-            CGFloat rotation = -MGLRadiansFromDegrees(self.mapView.direction - self.userLocation.heading.trueHeading);
+            CGFloat rotation = -MGLRadiansFromDegrees(self.mapView.direction - headingDirection);
 
             // Don't rotate if the change is imperceptible.
             if (fabs(rotation) > MGLUserLocationHeadingUpdateThreshold)

--- a/platform/ios/src/MGLUserLocation.m
+++ b/platform/ios/src/MGLUserLocation.m
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_END
 
 - (void)setHeading:(CLHeading *)newHeading
 {
-    if (newHeading.trueHeading != _heading.trueHeading)
+    if (newHeading.trueHeading != _heading.trueHeading || newHeading.magneticHeading != _heading.magneticHeading)
     {
         [self willChangeValueForKey:@"heading"];
         _heading = newHeading;


### PR DESCRIPTION
I found that the heading indicator does not rotate if Settings > Privacy > Location Services > System Services > Compass Calibration is off.

This issue can be reproduced by:
1. Turn off Settings > Privacy > Location Services > System Services > Compass Calibration.
2. Open a map in Mapbox Studio Preview.
3. Tap the location button.

You will see that the heading indicator will keep pointing upwards.

If you tap the location button again to set the tracking mode to followingWithHeading, the map can rotate properly. This is because followingWithHeading will fallback to use magneticHeading if trueHeading is invalid.

The pull request applies the same fallback logic to other uses of trueHeading.

Please review.