### PR TITLE
Fix crash when quitting while a map view has annotations

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -30,6 +30,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 ### Other changes
 
 * Added the `MGLMapView.minimumPitch` and `MGLMapView.maximumPitch` properties to further limit how much the user or your code can tilt the map. ([#208](https://github.com/mapbox/mapbox-gl-native-ios/pull/208))
+* Fixed a crash while quitting the application after adding an annotation to `MGLMapView`. ([#252](https://github.com/mapbox/mapbox-gl-native-ios/pull/252))
 * Improved performance when continuously animating a tilted map. ([#16287](https://github.com/mapbox/mapbox-gl-native/pull/16287))
 * Fixed a memory leak when zooming with any options enabled in the `MGLMapView.debugMask` property. ([#15179](https://github.com/mapbox/mapbox-gl-native/issues/15179))
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -4612,7 +4612,12 @@ public:
         }
 
         _isChangingAnnotationLayers = YES;
-        self.mbglMap.removeAnnotation(annotationTag);
+        // If the underlying map is gone, there’s nothing to remove, but still
+        // continue to unregister KVO and other annotation resources.
+        if (_mbglMap)
+        {
+            self.mbglMap.removeAnnotation(annotationTag);
+        }
     }
 
     [self updatePresentsWithTransaction];

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -154,7 +154,7 @@ public:
 
 @implementation MGLMapView {
     /// Cross-platform map view controller.
-    mbgl::Map *_mbglMap;
+    std::unique_ptr<mbgl::Map> _mbglMap;
     std::unique_ptr<MGLMapViewImpl> _mbglView;
     std::unique_ptr<MGLRenderFrontend> _rendererFrontend;
 
@@ -295,7 +295,7 @@ public:
     resourceOptions.withCachePath([[MGLOfflineStorage sharedOfflineStorage] mbglCachePath])
                    .withAssetPath([NSBundle mainBundle].resourceURL.path.UTF8String);
 
-    _mbglMap = new mbgl::Map(*_rendererFrontend, *_mbglView, mapOptions, resourceOptions);
+    _mbglMap = std::make_unique<mbgl::Map>(*_rendererFrontend, *_mbglView, mapOptions, resourceOptions);
 
     // Notify map object when network reachability status changes.
     _reachability = [MGLReachability reachabilityForInternetConnection];
@@ -539,10 +539,7 @@ public:
     // Removing the annotations unregisters any outstanding KVO observers.
     [self removeAnnotations:self.annotations];
 
-    if (_mbglMap) {
-        delete _mbglMap;
-        _mbglMap = nullptr;
-    }
+    _mbglMap.reset();
     _mbglView.reset();
 }
 
@@ -660,10 +657,6 @@ public:
 - (void)setPrefetchesTiles:(BOOL)prefetchesTiles
 {
     _mbglMap->setPrefetchZoomDelta(prefetchesTiles ? mbgl::util::DEFAULT_PREFETCH_ZOOM_DELTA : 0);
-}
-
-- (mbgl::Map *)mbglMap {
-    return _mbglMap;
 }
 
 - (mbgl::Renderer *)renderer {

--- a/platform/macos/src/MGLMapView_Private.h
+++ b/platform/macos/src/MGLMapView_Private.h
@@ -55,8 +55,6 @@ namespace mbgl {
 
 - (BOOL)isTargetingInterfaceBuilder;
 
-- (nonnull mbgl::Map *)mbglMap;
-
 - (nonnull mbgl::Renderer *)renderer;
 
 @end


### PR DESCRIPTION
If the underlying `mbgl::Map` has been torn down, so has the mbgl annotation, so don’t worry about the `mbgl::Map`, but keep unregistering KVO and other SDK-side annotation resources.

Also wrapped `MGLMapView`’s `mbgl::Map` reference in a `std::unique_ptr` for increased pointer safety.

Fixes #87.

<!-- `<changelog>Fixed a crash while quitting the application after adding an annotation to `MGLMapView`.</changelog>` -->

/cc @mapbox/maps-ios
