### PR TITLE
Fix unit test compilation error

### DIFF
--- a/platform/darwin/test/MGLDocumentationExampleTests.swift
+++ b/platform/darwin/test/MGLDocumentationExampleTests.swift
@@ -480,6 +480,7 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
         //#-end-example-code
         
         wait(for: [expectation], timeout: 5)
+        _ = image
     }
     
     func testMGLCluster() {


### PR DESCRIPTION
Read and discard the local variable value to suppress the error. This variable is only a behind-the-scenes stand-in for an instance property.

Fixes #257.

/cc @mapbox/maps-ios