### PR TITLE
Initialize offline storage on main thread before snapshotting

### DIFF
--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -301,9 +301,14 @@ private:
     if (!completion) {
         return;
     }
-    if (!mbgl::Scheduler::GetCurrent()) {
+    
+    // Ensure that offline storage has been initialized on the main thread, as MGLMapView and MGLOfflineStorage do when used directly.
+    // https://github.com/mapbox/mapbox-gl-native-ios/issues/227
+    if ([NSThread.currentThread isMainThread]) {
+        (void)[MGLOfflineStorage sharedOfflineStorage];
+    } else {
         [NSException raise:NSInvalidArgumentException
-                    format:@"startWithQueue:completionHandler: must be called from a thread with an active run loop."];
+                    format:@"-[MGLMapSnapshotter startWithQueue:completionHandler:] must be called from the main thread, not %@.", NSThread.currentThread];
     }
 
     if (self.loading) {

--- a/platform/darwin/test/MGLMapSnapshotterTests.m
+++ b/platform/darwin/test/MGLMapSnapshotterTests.m
@@ -62,10 +62,6 @@ MGLImage *MGLImageFromCurrentContext() {
     [super setUp];
     
     [MGLAccountManager setAccessToken:@"pk.feedcafedeadbeefbadebede"];
-    
-    // Initialize file system and run loop before snapshotting.
-    // https://github.com/mapbox/mapbox-gl-native-ios/issues/227
-    (void)[MGLOfflineStorage sharedOfflineStorage];
 }
 
 - (void)tearDown {


### PR DESCRIPTION
Ensure that offline storage has been initialized on the main thread, as MGLMapView and MGLOfflineStorage do when used directly. This fixes a regression introduced in #210 as well as fixing some potential undefined behavior from previous releases if MGLMapSnapshotter had been used on a background thread before any direct MGLOfflineStorage or MGLMapView usage.

Fixes #227.

/cc @mapbox/maps-ios