### PR TITLE
Adopt Apple Generic Versioning on macOS

### DIFF
--- a/platform/darwin/test/MGLVersionNumber.m
+++ b/platform/darwin/test/MGLVersionNumber.m
@@ -9,7 +9,12 @@
 @implementation MGLVersionTests
 
 - (void)testVersionNumber {
+#if TARGET_OS_IPHONE
     XCTAssertEqual(1, MapboxVersionNumber);
+#else
+    XCTAssertGreaterThan(MapboxVersionNumber, 1);
+    XCTAssertGreaterThan(MapboxVersionString[0] + MapboxVersionString[1] + MapboxVersionString[2], 0);
+#endif
 }
 
 @end

--- a/platform/macos/app/Info.plist
+++ b/platform/macos/app/Info.plist
@@ -30,7 +30,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>0.15.0</string>
 	<key>CFBundleSignature</key>
 	<string>MBGL</string>
 	<key>CFBundleURLTypes</key>
@@ -45,7 +45,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>15252</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSMainNibFile</key>

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -2000,8 +2000,9 @@
 				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_COMMIT_HASH = deadbeef;
-				CURRENT_SEMANTIC_VERSION = 1.0.0;
-				CURRENT_SHORT_VERSION = 1.0;
+				CURRENT_PROJECT_VERSION = 15252;
+				CURRENT_SEMANTIC_VERSION = 0.15.0;
+				CURRENT_SHORT_VERSION = 0.15.0;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -2030,6 +2031,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SYMROOT = "$(PROJECT_DIR)/cmake";
+				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
 		};
@@ -2067,8 +2069,9 @@
 				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_COMMIT_HASH = deadbeef;
-				CURRENT_SEMANTIC_VERSION = 1.0.0;
-				CURRENT_SHORT_VERSION = 1.0;
+				CURRENT_PROJECT_VERSION = 15252;
+				CURRENT_SEMANTIC_VERSION = 0.15.0;
+				CURRENT_SHORT_VERSION = 0.15.0;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -2092,6 +2095,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SYMROOT = "$(PROJECT_DIR)/cmake";
+				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
 		};
@@ -2102,7 +2106,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
-				INFOPLIST_FILE = "$(SRCROOT)/app/Info.plist";
+				INFOPLIST_FILE = app/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				OTHER_CFLAGS = "-fvisibility=hidden";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGL;
@@ -2119,7 +2123,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
-				INFOPLIST_FILE = "$(SRCROOT)/app/Info.plist";
+				INFOPLIST_FILE = app/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				OTHER_CFLAGS = "-fvisibility=hidden";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGL;
@@ -2158,13 +2162,12 @@
 			baseConfigurationReference = DAC832622404AF4300A61BF8 /* macos.xcconfig */;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 15252;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
-				INFOPLIST_FILE = "$(SRCROOT)/sdk/Info.plist";
+				INFOPLIST_FILE = sdk/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				OTHER_CFLAGS = "-fvisibility=hidden";
@@ -2181,15 +2184,14 @@
 			baseConfigurationReference = DAC832622404AF4300A61BF8 /* macos.xcconfig */;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DEPLOYMENT_POSTPROCESSING = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 15252;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
-				INFOPLIST_FILE = "$(SRCROOT)/sdk/Info.plist";
+				INFOPLIST_FILE = sdk/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				LLVM_LTO = YES;

--- a/platform/macos/scripts/package.sh
+++ b/platform/macos/scripts/package.sh
@@ -33,8 +33,6 @@ fi
 
 step "Building dynamic framework (build ${PROJ_VERSION}, version ${SEM_VERSION})…"
 xcodebuild \
-    CURRENT_PROJECT_VERSION=${PROJ_VERSION} \
-    CURRENT_SHORT_VERSION=${SHORT_VERSION} \
     CURRENT_SEMANTIC_VERSION=${SEM_VERSION} \
     CURRENT_COMMIT_HASH=${HASH} \
     ${CI_XCCONFIG} \
@@ -57,8 +55,6 @@ step "Building and archiving Mapbox GL.app (build ${PROJ_VERSION}, version ${SEM
 if [[ ${BUILDTYPE} == Release ]]; then
     mkdir -p ${APP_OUTPUT}
     xcodebuild \
-        CURRENT_PROJECT_VERSION=${PROJ_VERSION} \
-        CURRENT_SHORT_VERSION=${SHORT_VERSION} \
         CURRENT_SEMANTIC_VERSION=${SEM_VERSION} \
         CURRENT_COMMIT_HASH=${HASH} \
         ${CI_XCCONFIG} \

--- a/platform/macos/scripts/update-version.sh
+++ b/platform/macos/scripts/update-version.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -u
+
+function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
+function finish { >&2 echo -en "\033[0m"; }
+trap finish EXIT
+
+if [ $# -eq 0 ]; then
+    echo "Usage: v<semantic version>"
+    exit 1
+fi
+
+SEM_VERSION=$1
+SEM_VERSION=${SEM_VERSION/#macos-}
+SEM_VERSION=${SEM_VERSION/#v}
+SHORT_VERSION=${SEM_VERSION%-*}
+
+step "Version ${SEM_VERSION}"
+
+cd platform/macos/
+
+step "Updating Xcode targets to version ${SHORT_VERSION}…"
+
+xcrun agvtool bump -all
+xcrun agvtool new-marketing-version "${SHORT_VERSION}"
+
+step "Updating CocoaPods podspecs to version ${SEM_VERSION}…"
+
+find . -type f -name '*.podspec' -exec sed -i '' "s/^ *version *=.*$/  version = '${SEM_VERSION}'/" {} +

--- a/platform/macos/sdk/Info.plist
+++ b/platform/macos/sdk/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleShortVersionString</key>
-	<string>$(CURRENT_SHORT_VERSION)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
@@ -16,10 +14,12 @@
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.15.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>15252</string>
 	<key>MGLCommitHash</key>
 	<string>$(CURRENT_COMMIT_HASH)</string>
 	<key>MGLSemanticVersionString</key>

--- a/platform/macos/test/Info.plist
+++ b/platform/macos/test/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.15.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>15252</string>
 </dict>
 </plist>


### PR DESCRIPTION
Added a script to update the macOS map SDK’s version in all the relevant places before releasing a new version. Example usage and output:

```
$ ./platform/macos/scripts/update-version.sh v0.15.0-beta.1
* Version 0.15.0-beta.1
* Updating Xcode targets to version 0.15.0…
Setting version of project macos to: 
    15253.

Also setting CFBundleVersion key (assuming it exists)

Updating CFBundleVersion in Info.plist(s)...

Updated CFBundleVersion in "macos.xcodeproj/../app/Info.plist" to 15253
Updated CFBundleVersion in "macos.xcodeproj/../sdk/Info.plist" to 15253
Updated CFBundleVersion in "macos.xcodeproj/../test/Info.plist" to 15253


Setting CFBundleShortVersionString of project macos to: 
    0.15.0.

Updating CFBundleShortVersionString in Info.plist(s)...

Updated CFBundleShortVersionString in "macos.xcodeproj/../app/Info.plist" to 0.15.0
Updated CFBundleShortVersionString in "macos.xcodeproj/../sdk/Info.plist" to 0.15.0
Updated CFBundleShortVersionString in "macos.xcodeproj/../test/Info.plist" to 0.15.0
* Updating CocoaPods podspecs to version 0.15.0-beta.1…
```

This cuts out a couple manual release steps and makes the version more consistent across builds.

Fixes the macOS half of #262 to demonstrate the feasibility of fixing the iOS half.

/cc @mapbox/maps-ios