### PR TITLE
[ios] add allowScrollGesturesDuringRotateOrZoom

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -28,7 +28,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * When an offline pack encounters an HTTP 404 error, the `MGLOfflinePackUserInfoKeyError` user info key of the `MGLOfflinePackErrorNotification` now indicates the resource that could not be downloaded. ([#16240](https://github.com/mapbox/mapbox-gl-native/pull/16240))
 
 ### Other changes
-
+* Added `MGLMapView.anchorRotateOrZoomGesturesToCenterCoordinate` property that anchors zoom and rotating gestures to the map's view center coordinate. ([#268](https://github.com/mapbox/mapbox-gl-native-ios/pull/268))
 * Added the `MGLMapView.minimumPitch` and `MGLMapView.maximumPitch` properties to further limit how much the user or your code can tilt the map. ([#208](https://github.com/mapbox/mapbox-gl-native-ios/pull/208))
 * Fixed a crash while quitting the application after adding an annotation to `MGLMapView`. ([#252](https://github.com/mapbox/mapbox-gl-native-ios/pull/252))
 * Improved performance when continuously animating a tilted map. ([#16287](https://github.com/mapbox/mapbox-gl-native/pull/16287))

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -741,6 +741,10 @@ MGL_EXPORT
 @property(nonatomic, getter=isPitchEnabled) BOOL pitchEnabled;
 
 /**
+ A Boolean value that determines whether the user can change the center coordinate of the map while rotating or zooming. When this property is set to YES, the default, the location of the gesture in the map view determines the map's center coordinate.
+ */
+@property(nonatomic) BOOL allowScrollGesturesDuringRotateOrZoom;
+/**
  A Boolean value that determines whether the user will receive haptic feedback
  for certain interactions with the map.
 

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -741,9 +741,10 @@ MGL_EXPORT
 @property(nonatomic, getter=isPitchEnabled) BOOL pitchEnabled;
 
 /**
- A Boolean value that determines whether the user can change the center coordinate of the map while rotating or zooming. When this property is set to YES, the default, the location of the gesture in the map view determines the map's center coordinate.
+ A Boolean value that determines whether gestures are anchored to the center coordinate of the map while rotating or zooming.
+ Default value is set to NO.
  */
-@property(nonatomic) BOOL allowScrollGesturesDuringRotateOrZoom;
+@property(nonatomic) BOOL anchorRotateOrZoomGesturesToCenterCoordinate;
 /**
  A Boolean value that determines whether the user will receive haptic feedback
  for certain interactions with the map.

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -586,7 +586,7 @@ public:
     // setup interaction
     //
 
-    self.allowScrollGesturesDuringRotateOrZoom = YES;
+    self.anchorRotateOrZoomGesturesToCenterCoordinate = NO;
 
     _pan = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePanGesture:)];
     _pan.delegate = self;
@@ -1717,12 +1717,6 @@ public:
 {
     if ( ! self.isScrollEnabled) return;
 
-    if (!self.allowScrollGesturesDuringRotateOrZoom) {
-        if (self.isZooming || self.isRotating) {
-            return;
-        }
-    }
-
     [self cancelTransitions];
 
     MGLMapCamera *oldCamera = self.camera;
@@ -1801,7 +1795,7 @@ public:
     [self cancelTransitions];
 
     CGPoint centerPoint = [self anchorPointForGesture:pinch];
-    if (!self.allowScrollGesturesDuringRotateOrZoom) {
+    if (self.anchorRotateOrZoomGesturesToCenterCoordinate) {
         if (pinch.numberOfTouches != 1 || pinch.state == UIGestureRecognizerStateEnded) {
             centerPoint = [self contentCenter];
         }
@@ -1914,7 +1908,7 @@ public:
     [self cancelTransitions];
 
     CGPoint centerPoint = [self anchorPointForGesture:rotate];
-    if (!self.allowScrollGesturesDuringRotateOrZoom) {
+    if (self.anchorRotateOrZoomGesturesToCenterCoordinate) {
         centerPoint = [self contentCenter];
     }
     MGLMapCamera *oldCamera = self.camera;
@@ -1927,7 +1921,7 @@ public:
     // Check whether a zoom triggered by a pinch gesture is occurring and if the rotation threshold has been met.
     if (MGLDegreesFromRadians(self.rotationBeforeThresholdMet) < self.rotationThresholdWhileZooming && self.isZooming && !self.isRotating) {
         self.rotationBeforeThresholdMet += fabs(rotate.rotation);
-        if (!self.allowScrollGesturesDuringRotateOrZoom) {
+        if (self.anchorRotateOrZoomGesturesToCenterCoordinate) {
             self.rotationBeforeThresholdMet = 0;
         }
         rotate.rotation = 0;
@@ -2451,6 +2445,14 @@ public:
         {
             id<MGLAnnotation> annotation = [self annotationForGestureRecognizer:(UITapGestureRecognizer*)gestureRecognizer persistingResults:NO];
             if (!annotation) {
+                return NO;
+            }
+        }
+    }
+    else if (gestureRecognizer == _pan)
+    {
+        if (self.anchorRotateOrZoomGesturesToCenterCoordinate) {
+            if (self.isZooming || self.isRotating) {
                 return NO;
             }
         }


### PR DESCRIPTION
Added new property `MGLMapView.allowScrollGesturesDuringRotateOrZoom`, which allows you to change the center coordinate of the map while rotating or zooming
