### PR TITLE
Snapshot style’s default camera unless overridden

### DIFF
--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -736,10 +736,18 @@ NSArray<MGLAttributionInfo *> *MGLAttributionInfosFromAttributions(mbgl::MapSnap
     if (CLLocationCoordinate2DIsValid(options.camera.centerCoordinate)) {
         cameraOptions.center = MGLLatLngFromLocationCoordinate2D(options.camera.centerCoordinate);
     }
-    cameraOptions.bearing = MAX(0, options.camera.heading);
-    cameraOptions.zoom = MAX(0, options.zoomLevel);
-    cameraOptions.pitch = MAX(0, options.camera.pitch);
-    _mbglMapSnapshotter->setCameraOptions(cameraOptions);
+    if (options.camera.heading >= 0) {
+        cameraOptions.bearing = MAX(0, options.camera.heading);
+    }
+    if (options.zoomLevel >= 0) {
+        cameraOptions.zoom = MAX(0, options.zoomLevel);
+    }
+    if (options.camera.pitch >= 0) {
+        cameraOptions.pitch = MAX(0, options.camera.pitch);
+    }
+    if (cameraOptions != mbgl::CameraOptions()) {
+        _mbglMapSnapshotter->setCameraOptions(cameraOptions);
+    }
     
     // Region
     if (!MGLCoordinateBoundsIsEmpty(options.coordinateBounds)) {

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -8,6 +8,10 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Fixed an issue where properties such as `MGLFillStyleLayer.fillColor` and `MGLLineStyleLayer.lineColor` misinterpreted non-opaque `UIColor`s. ([#266](https://github.com/mapbox/mapbox-gl-native-ios/pull/266))
 
+### Other changes
+
+* Fixed an issue where an `MGLMapSnapshotOptions` with an invalid `MGLMapCamera.centerCoordinate`, negative `MGLMapCamera.heading`, negative `MGLMapCamera.pitch`, and negative `MGLMapSnapshotOptions.zoomLevel` resulted in a snapshot centered on Null Island at zoom level 0 even if the style specified a different initial center coordinate or zoom level. ([#280](https://github.com/mapbox/mapbox-gl-native-ios/pull/280))
+
 ## 5.8.0
 
 ### Styles and rendering

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for Mapbox Maps SDK for macOS
 
+## master
+
+### Other changes
+
+* Fixed an issue where an `MGLMapSnapshotOptions` with an invalid `MGLMapCamera.centerCoordinate`, negative `MGLMapCamera.heading`, negative `MGLMapCamera.pitch`, and negative `MGLMapSnapshotOptions.zoomLevel` resulted in a snapshot centered on Null Island at zoom level 0 even if the style specified a different initial center coordinate or zoom level. ([#280](https://github.com/mapbox/mapbox-gl-native-ios/pull/280))
+
 ## 0.15.0
 
 ### Styles and rendering


### PR DESCRIPTION
Only set a snapshotter’s underlying camera options – overriding the style’s default – if the application has set a valid `MGLMapCamera.centerCoordinate`, nonnegative `MGLMapCamera.heading`, nonnegative `MGLMapCamera.pitch`, or nonnegative `MGLMapSnapshotOptions.zoomLevel`.

Fixes #279.

<!-- `<changelog>Fixed an issue where an `MGLMapSnapshotOptions` with an invalid `MGLMapCamera.centerCoordinate`, negative `MGLMapCamera.heading`, negative `MGLMapCamera.pitch`, and negative `MGLMapSnapshotOptions.zoomLevel` resulted in a snapshot centered on Null Island at zoom level 0 even if the style specified a different initial center coordinate or zoom level.</changelog>` -->

/cc @mapbox/maps-ios