### PR TITLE
Add offline pack context setter

### DIFF
--- a/platform/darwin/src/MGLOfflinePack.h
+++ b/platform/darwin/src/MGLOfflinePack.h
@@ -131,8 +131,27 @@ MGL_EXPORT
 
  The context typically holds application-specific information for identifying
  the pack, such as a user-selected name.
+ 
+ To change the value of this property, use the `-setContext:completionHandler:`
+ method. If you access this property after calling that method but before its
+ completion handler is called, this property’s value may not reflect the new
+ value that you specify.
  */
 @property (nonatomic, readonly) NSData *context;
+
+/**
+ Associates arbitrary contextual data with the offline pack, replacing any
+ context that was previously associated with the offline pack.
+ 
+ Setting the context is asynchronous. The `context` property may not be updated
+ until the completion handler is called.
+ 
+ @param context The new context to associate with the offline pack.
+ @param completion The completion handler to call when the context has been
+    updated. If there is an error setting the context, the error is passed into
+    the completion handler.
+ */
+- (void)setContext:(NSData *)context completionHandler:(void (^_Nullable)(NSError * _Nullable error))completion;
 
 /**
  The pack’s current state.

--- a/platform/darwin/src/MGLOfflineStorage_Private.h
+++ b/platform/darwin/src/MGLOfflineStorage_Private.h
@@ -31,6 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) std::string mbglCachePath;
 
+- (void)getPacksWithCompletionHandler:(void (^)(NSArray<MGLOfflinePack *> *packs, NSError * _Nullable error))completion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/platform/darwin/test/MGLOfflineStorageTests.mm
+++ b/platform/darwin/test/MGLOfflineStorageTests.mm
@@ -139,6 +139,22 @@
     }];
     [pack requestProgress];
     [self waitForExpectationsWithTimeout:5 handler:nil];
+    
+    XCTAssertEqualObjects(pack.context, context, @"Offline pack context should match the context specified by the application.");
+    NSString *newName = @"🍑 Peach Grove";
+    NSData *newContext = [NSKeyedArchiver archivedDataWithRootObject:@{
+        nameKey: newName,
+    }];
+    
+    XCTestExpectation *contextCompletionHandlerExpectation = [self expectationWithDescription:@"set pack completion context handler"];
+    __weak MGLOfflinePack *weakPack = pack;
+    [pack setContext:newContext completionHandler:^(NSError * _Nullable error) {
+        XCTAssertNil(error);
+        XCTAssertNotNil(weakPack);
+        XCTAssertEqualObjects(weakPack.context, newContext, @"Offline pack context should match the updated context specified by the application.");
+        [contextCompletionHandlerExpectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:5 handler:nil];
 }
 
 - (void)testAddPackForGeometry {

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -17,6 +17,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ### Other changes
 
+* Added the `-[MGLOfflinePack setContext:completionHandler:]` method for replacing the data associated with an offline pack, such as a name. ([#288](https://github.com/mapbox/mapbox-gl-native-ios/pull/288))
 * Fixed a crash when encountering an invalid polyline. ([mapbox/mapbox-gl-native#16409](https://github.com/mapbox/mapbox-gl-native/pull/16409))
 * Fixed an issue where an `MGLMapSnapshotOptions` with an invalid `MGLMapCamera.centerCoordinate`, negative `MGLMapCamera.heading`, negative `MGLMapCamera.pitch`, and negative `MGLMapSnapshotOptions.zoomLevel` resulted in a snapshot centered on Null Island at zoom level 0 even if the style specified a different initial center coordinate or zoom level. ([#280](https://github.com/mapbox/mapbox-gl-native-ios/pull/280))
 * Fixed an error that occurred if your implementation of the `-[MGLOfflineStorageDelegate offlineStorage:URLForResourceOfKind:]` method returned a local file URL. ([mapbox/mapbox-gl-native#16428](https://github.com/mapbox/mapbox-gl-native/pull/16428)) 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -15,11 +15,15 @@
 
 ### Other changes
 
-* Fixed various crashes, including crashes on launch, on macOS 10.11.0 through 10.14._x_. ([mapbox/mapbox-gl-native#16412](https://github.com/mapbox/mapbox-gl-native/pull/16412))
+* Added the `-[MGLOfflinePack setContext:completionHandler:]` method for replacing the data associated with an offline pack, such as a name. ([#288](https://github.com/mapbox/mapbox-gl-native-ios/pull/288))
 * Fixed a crash when encountering an invalid polyline. ([mapbox/mapbox-gl-native#16409](https://github.com/mapbox/mapbox-gl-native/pull/16409))
 * Fixed an issue where an `MGLMapSnapshotOptions` with an invalid `MGLMapCamera.centerCoordinate`, negative `MGLMapCamera.heading`, negative `MGLMapCamera.pitch`, and negative `MGLMapSnapshotOptions.zoomLevel` resulted in a snapshot centered on Null Island at zoom level 0 even if the style specified a different initial center coordinate or zoom level. ([#280](https://github.com/mapbox/mapbox-gl-native-ios/pull/280))
 * Fixed an error that occurred if your implementation of the `-[MGLOfflineStorageDelegate offlineStorage:URLForResourceOfKind:]` method returned a local file URL. ([mapbox/mapbox-gl-native#16428](https://github.com/mapbox/mapbox-gl-native/pull/16428)) 
 * Certain logging statements no longer run on the main thread. ([mapbox/mapbox-gl-native#16325](https://github.com/mapbox/mapbox-gl-native/pull/16325))
+
+## 0.15.1
+
+* Fixed various crashes, including crashes on launch, on macOS 10.11.0 through 10.14._x_. ([mapbox/mapbox-gl-native#16412](https://github.com/mapbox/mapbox-gl-native/pull/16412))
 
 ## 0.15.0
 


### PR DESCRIPTION
Added the `-[MGLOfflinePack setContext:completionHandler:]` method for replacing the data associated with an offline pack, such as a name.

To do:

* [x] Add setter
* [x] Add unit test of setter
* [x] Debug unit test failure
* [ ] Make offline pack table editable in macosapp

Fixes #256.

<!-- `<changelog>Added the `-[MGLOfflinePack setContext:completionHandler:]` method for replacing the data associated with an offline pack, such as a name.</changelog>` -->

/cc @mapbox/maps-ios