### PR TITLE
Hard-code Null Island for runtime styling test

### DIFF
--- a/platform/darwin/test/one-liner.json
+++ b/platform/darwin/test/one-liner.json
@@ -1,1 +1,1 @@
-{"version":8,"sources":{},"layers":[],"center":[0,0],"zoom":0}
+{"version":8,"sources":{},"layers":[]}


### PR DESCRIPTION
Relying on the stylesheet to jump from an invalid camera to Null Island seems to introduce a race condition in mbgl where the tiles don’t render by the time the snapshot takes place. Hard-coding the default camera as the snapshot’s camera merely makes the test failure less frequent on CI, but there is very likely an underlying issue: mapbox/mapbox-gl-native#16454.

Fixes #291.

/cc @mapbox/maps-ios