### PR TITLE
Make offline database path configurable

### DIFF
--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -721,7 +721,7 @@ NSArray<MGLAttributionInfo *> *MGLAttributionInfosFromAttributions(mbgl::MapSnap
     MGLRendererConfiguration *config = [MGLRendererConfiguration currentConfiguration];
 
     mbgl::ResourceOptions resourceOptions;
-    resourceOptions.withCachePath(MGLOfflineStorage.sharedOfflineStorage.mbglCachePath)
+    resourceOptions.withCachePath(MGLOfflineStorage.sharedOfflineStorage.databasePath.UTF8String)
                    .withAssetPath(NSBundle.mainBundle.resourceURL.path.UTF8String);
 
     // Create the snapshotter

--- a/platform/darwin/src/MGLOfflineStorage.h
+++ b/platform/darwin/src/MGLOfflineStorage.h
@@ -201,42 +201,6 @@ MGL_EXPORT
  */
 @property (class, nonatomic, readonly) MGLOfflineStorage *sharedOfflineStorage;
 
-#pragma mark - Adding Contents of File
-
-/**
- Adds the offline packs located at the given file path to offline storage.
- 
- The file must be a valid offline region database bundled with the application
- or downloaded separately.
- 
- The resulting packs are added or updated to the shared offline storage object’s `packs`
- property, then the `completion` block is executed.
- 
- @param filePath A string representation of the file path. The file path must be
- writable as schema updates may be perfomed.
- @param completion The completion handler to call once the contents of the given
- file has been added to offline storage. This handler is executed asynchronously
- on the main queue.
- */
-- (void)addContentsOfFile:(NSString *)filePath withCompletionHandler:(nullable MGLBatchedOfflinePackAdditionCompletionHandler)completion;
-
-/**
- Adds the offline packs located at the given URL to offline storage.
- 
- The file must be a valid offline region database bundled with the application
- or downloaded separately.
- 
- The resulting packs are added or updated to the shared offline storage object’s `packs`
- property, then the `completion` block is executed.
- 
- @param fileURL A file URL specifying the file to add. URL should be a valid system path.
- The file URL must be writable as schema updates may be performed.
- @param completion The completion handler to call once the contents of the given
- file has been added to offline storage. This handler is executed asynchronously
- on the main queue.
- */
-- (void)addContentsOfURL:(NSURL *)fileURL withCompletionHandler:(nullable MGLBatchedOfflinePackAdditionCompletionHandler)completion;
-
 #pragma mark - Accessing the Delegate
 
 /**
@@ -248,6 +212,52 @@ MGL_EXPORT
  or endpoints.
  */
 @property(nonatomic, weak, nullable) IBOutlet id<MGLOfflineStorageDelegate> delegate;
+
+#pragma mark - Managing the Database of Offline Packs
+
+/**
+ The file path at which offline packs and the ambient cache are stored.
+ */
+@property (nonatomic, readonly, copy) NSString *databasePath;
+
+/**
+ The file URL at which offline packs and the ambient cache are stored.
+ */
+@property (nonatomic, readonly, copy) NSURL *databaseURL;
+
+/**
+ Adds the offline packs located at the given file path to offline storage.
+ 
+ The file must be a valid offline pack database bundled with the application or
+ downloaded separately.
+ 
+ The resulting packs are added or updated to the shared offline storage object’s
+ `packs` property, then the `completion` block is executed.
+ 
+ @param filePath A string representation of the file path. The file path must be
+    writable as schema updates may be perfomed.
+ @param completion The completion handler to call once the contents of the given
+    file has been added to offline storage. This handler is executed
+    asynchronously on the main queue.
+ */
+- (void)addContentsOfFile:(NSString *)filePath withCompletionHandler:(nullable MGLBatchedOfflinePackAdditionCompletionHandler)completion;
+
+/**
+ Adds the offline packs located at the given URL to offline storage.
+ 
+ The file must be a valid offline pack database bundled with the application or
+ downloaded separately.
+ 
+ The resulting packs are added or updated to the shared offline storage object’s
+ `packs` property, then the `completion` block is executed.
+ 
+ @param fileURL A file URL specifying the file to add. The URL should be a valid
+    system path. The URL must be writable as schema updates may be performed.
+ @param completion The completion handler to call once the contents of the given
+    file has been added to offline storage. This handler is executed
+    asynchronously on the main queue.
+ */
+- (void)addContentsOfURL:(NSURL *)fileURL withCompletionHandler:(nullable MGLBatchedOfflinePackAdditionCompletionHandler)completion;
 
 #pragma mark - Managing Offline Packs
 
@@ -367,8 +377,7 @@ MGL_EXPORT
  */
 @property (nonatomic, readonly) unsigned long long countOfBytesCompleted;
 
-
-#pragma mark - Managing Ambient Cache
+#pragma mark - Managing the Ambient Cache
 
 /**
  Sets the maximum ambient cache size in bytes. The default maximum cache
@@ -388,10 +397,9 @@ MGL_EXPORT
  specified amount.
  
  @param cacheSize The maximum size in bytes for the ambient cache.
- @param completion The completion handler to call once the maximum ambient cache size
- has been set. This handler is executed synchronously on the main queue.
+ @param completion The completion handler to call once the maximum ambient cache
+    size has been set. This handler is executed synchronously on the main queue.
  */
-
 - (void)setMaximumAmbientCacheSize:(NSUInteger)cacheSize withCompletionHandler:(void (^)(NSError *_Nullable error))completion;
 
 /**
@@ -405,32 +413,29 @@ MGL_EXPORT
  Resources shared with offline packs will not be affected by this method.
  
  @param completion The completion handler to call once the ambient cache has
- been revalidated. This handler is executed asynchronously on the main queue.
+    been revalidated. This handler is executed asynchronously on the main queue.
  */
-
 - (void)invalidateAmbientCacheWithCompletionHandler:(void (^)(NSError *_Nullable error))completion;
 
 /**
- Clears the ambient cache by deleting resources. This method does not
- affect resources shared with offline regions.
+ Clears the ambient cache by deleting resources. This method does not affect
+ resources shared with offline regions.
  
- @param completion The completion handler to call once resources from
- the ambient cache have been cleared. This handler is executed
- asynchronously on the main queue.
+ @param completion The completion handler to call once resources from the
+    ambient cache have been cleared. This handler is executed asynchronously on
+    the main queue.
  */
 
 - (void)clearAmbientCacheWithCompletionHandler:(void (^)(NSError *_Nullable error))completion;
-
 /**
- Deletes the existing database, which includes both the ambient cache and offline packs,
- then reinitializes it.
+ Deletes the existing database, which includes both the ambient cache and
+ offline packs, then reinitializes it.
  
  You typically do not need to call this method.
  
  @param completion The completion handler to call once the pack has database has
  been reset. This handler is executed asynchronously on the main queue.
  */
-
 - (void)resetDatabaseWithCompletionHandler:(void (^)(NSError *_Nullable error))completion;
 
 /**
@@ -444,7 +449,8 @@ MGL_EXPORT
  in-progress requests, though subsequent requests should have access to the
  cached data.
 
- To find out when the resource is ready to retrieve from the cache, use the -preloadData:forURL:modificationDate:expirationDate:eTag:mustRevalidate:completionHandler: method.
+ To find out when the resource is ready to retrieve from the cache, use the `-preloadData:forURL:modificationDate:expirationDate:eTag:mustRevalidate:completionHandler:`
+ method.
 
  @param data Response data to store for this resource. The data is expected to
     be uncompressed; internally, the cache will compress data as necessary.
@@ -460,25 +466,26 @@ MGL_EXPORT
 - (void)putResourceWithUrl:(NSURL *)url data:(NSData *)data modified:(nullable NSDate *)modified expires:(nullable NSDate *)expires etag:(nullable NSString *)etag mustRevalidate:(BOOL)mustRevalidate __attribute__((deprecated("", "-preloadData:forURL:modificationDate:expirationDate:eTag:mustRevalidate:")));
 
 /**
-Inserts the provided resource into the ambient cache, calling a completion handler when finished.
+ Inserts the provided resource into the ambient cache, calling a completion
+ handler when finished.
 
-This method is asynchronous. The data is available for in-progress requests as
-soon as the completion handler is called.
+ This method is asynchronous. The data is available for in-progress requests as
+ soon as the completion handler is called.
 
-This method is asynchronous; the data may not be immediately available for
-in-progress requests, though subsequent requests should have access to the
-cached data.
+ This method is asynchronous; the data may not be immediately available for
+ in-progress requests, though subsequent requests should have access to the
+ cached data.
 
-@param data Response data to store for this resource. The data is expected to
-   be uncompressed; internally, the cache will compress data as necessary.
-@param url The URL at which the data can normally be found.
-@param modified The date the resource was last modified.
-@param expires The date after which the resource is no longer valid.
-@param eTag An HTTP entity tag.
-@param mustRevalidate A Boolean value indicating whether the data is still
-   usable past the expiration date.
-@param completion The completion handler to call once the data has been preloaded.
-This handler is executed asynchronously on the main queue.
+ @param data Response data to store for this resource. The data is expected to
+    be uncompressed; internally, the cache will compress data as necessary.
+ @param url The URL at which the data can normally be found.
+ @param modified The date the resource was last modified.
+ @param expires The date after which the resource is no longer valid.
+ @param eTag An HTTP entity tag.
+ @param mustRevalidate A Boolean value indicating whether the data is still
+    usable past the expiration date.
+ @param completion The completion handler to call once the data has been
+    preloaded. This handler is executed asynchronously on the main queue.
 */
 - (void)preloadData:(NSData *)data forURL:(NSURL *)url modificationDate:(nullable NSDate *)modified expirationDate:(nullable NSDate *)expires eTag:(nullable NSString *)eTag mustRevalidate:(BOOL)mustRevalidate
     completionHandler:(nullable MGLOfflinePreloadDataCompletionHandler)completion;

--- a/platform/darwin/src/MGLOfflineStorage.h
+++ b/platform/darwin/src/MGLOfflineStorage.h
@@ -217,11 +217,19 @@ MGL_EXPORT
 
 /**
  The file path at which offline packs and the ambient cache are stored.
+ 
+ To customize this path, specify the
+ [`MGLOfflineStorageDatabasePath`](../infoplist-keys.html#mglofflinestoragedatabasepath)
+ key in Info.plist.
  */
 @property (nonatomic, readonly, copy) NSString *databasePath;
 
 /**
  The file URL at which offline packs and the ambient cache are stored.
+ 
+ To customize this path, specify the
+ [`MGLOfflineStorageDatabasePath`](../infoplist-keys.html#mglofflinestoragedatabasepath)
+ key in Info.plist.
  */
 @property (nonatomic, readonly, copy) NSURL *databaseURL;
 

--- a/platform/darwin/src/MGLOfflineStorage_Private.h
+++ b/platform/darwin/src/MGLOfflineStorage_Private.h
@@ -26,11 +26,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) std::shared_ptr<mbgl::FileSource> mbglFileSource;
 
-/**
- The shared offline cache path.
- */
-@property (nonatomic) std::string mbglCachePath;
-
 - (void)getPacksWithCompletionHandler:(void (^)(NSArray<MGLOfflinePack *> *packs, NSError * _Nullable error))completion;
 
 @end

--- a/platform/darwin/test/MGLOfflineStorageTests.mm
+++ b/platform/darwin/test/MGLOfflineStorageTests.mm
@@ -26,12 +26,13 @@
     NSString *bundleIdentifier = [NSBundle mgl_applicationBundleIdentifier];
     cacheDirectoryURL = [cacheDirectoryURL URLByAppendingPathComponent:bundleIdentifier];
     cacheDirectoryURL = [cacheDirectoryURL URLByAppendingPathComponent:@".mapbox"];
-    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:cacheDirectoryURL.path], @"Cache subdirectory should exist.");
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:cacheDirectoryURL.path], @"Directory containing database should exist.");
     
     NSURL *cacheURL = [cacheDirectoryURL URLByAppendingPathComponent:@"cache.db"];
+    XCTAssertEqualObjects(cacheURL, MGLOfflineStorage.sharedOfflineStorage.databaseURL);
     
     [[NSFileManager defaultManager] removeItemAtURL:cacheURL error:nil];
-    XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath:cacheURL.path], @"Cache subdirectory should not exist.");
+    XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath:cacheURL.path], @"Database should not exist.");
 }
 
 - (void)setUp {

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -18,7 +18,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 ### Offline maps
 
 * Added the `-[MGLOfflinePack setContext:completionHandler:]` method for replacing the data associated with an offline pack, such as a name. ([#288](https://github.com/mapbox/mapbox-gl-native-ios/pull/288))
-* Added the `MGLOfflineStorage.databasePath` and `MGLOfflineStorage.databaseURL` properties. ([#298](https://github.com/mapbox/mapbox-gl-native-ios/pull/298))
+* Added the `MGLOfflineStorage.databasePath` and `MGLOfflineStorage.databaseURL` properties to obtain the path of the database that contains offline packs and the ambient cache. To customize this path, set the `MGLOfflineStorageDatabasePath` in Info.plist. ([#298](https://github.com/mapbox/mapbox-gl-native-ios/pull/298))
 * Fixed an error that occurred if your implementation of the `-[MGLOfflineStorageDelegate offlineStorage:URLForResourceOfKind:]` method returned a local file URL. ([mapbox/mapbox-gl-native#16428](https://github.com/mapbox/mapbox-gl-native/pull/16428)) 
 
 ### Other changes

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -15,12 +15,16 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed a crash when calling the `-[MGLStyle removeImageForName:]` method with the name of a nonexistent image. ([mapbox/mapbox-gl-native#16391](https://github.com/mapbox/mapbox-gl-native/pull/16391))
 * Fixed an issue where properties such as `MGLFillStyleLayer.fillColor` and `MGLLineStyleLayer.lineColor` misinterpreted non-opaque `UIColor`s. ([#266](https://github.com/mapbox/mapbox-gl-native-ios/pull/266))
 
-### Other changes
+### Offline maps
 
 * Added the `-[MGLOfflinePack setContext:completionHandler:]` method for replacing the data associated with an offline pack, such as a name. ([#288](https://github.com/mapbox/mapbox-gl-native-ios/pull/288))
+* Added the `MGLOfflineStorage.databasePath` and `MGLOfflineStorage.databaseURL` properties. ([#298](https://github.com/mapbox/mapbox-gl-native-ios/pull/298))
+* Fixed an error that occurred if your implementation of the `-[MGLOfflineStorageDelegate offlineStorage:URLForResourceOfKind:]` method returned a local file URL. ([mapbox/mapbox-gl-native#16428](https://github.com/mapbox/mapbox-gl-native/pull/16428)) 
+
+### Other changes
+
 * Fixed a crash when encountering an invalid polyline. ([mapbox/mapbox-gl-native#16409](https://github.com/mapbox/mapbox-gl-native/pull/16409))
 * Fixed an issue where an `MGLMapSnapshotOptions` with an invalid `MGLMapCamera.centerCoordinate`, negative `MGLMapCamera.heading`, negative `MGLMapCamera.pitch`, and negative `MGLMapSnapshotOptions.zoomLevel` resulted in a snapshot centered on Null Island at zoom level 0 even if the style specified a different initial center coordinate or zoom level. ([#280](https://github.com/mapbox/mapbox-gl-native-ios/pull/280))
-* Fixed an error that occurred if your implementation of the `-[MGLOfflineStorageDelegate offlineStorage:URLForResourceOfKind:]` method returned a local file URL. ([mapbox/mapbox-gl-native#16428](https://github.com/mapbox/mapbox-gl-native/pull/16428)) 
 * Certain logging statements no longer run on the main thread. ([mapbox/mapbox-gl-native#16325](https://github.com/mapbox/mapbox-gl-native/pull/16325))
 * Fixed an issue that prevented the Maps SDK from warning about a misconfiguration that violated the Mapbox ToS. ([#288](https://github.com/mapbox/mapbox-gl-native-ios/pull/288))
 

--- a/platform/ios/docs/guides/Info.plist Keys.md
+++ b/platform/ios/docs/guides/Info.plist Keys.md
@@ -30,6 +30,16 @@ This key can either be set to a single string or an array of strings, which the 
 
 To disable client-side rendering of CJK characters in favor of [server-side rendering](customizing-fonts.html#server-side-fonts), set this key to the Boolean value `NO`.
 
+## MGLOfflineStorageDatabasePath
+
+This key customizes the file path at which `MGLOfflineStorage` keeps the offline map database, which contains any offline packs as well as the ambient cache. Most applications should not need to customize this path; however, you could customize it to implement a migration path between different versions of your application.
+
+The key is interpreted as either an absolute file path or a file path relative to the main bundle’s resource folder, resolving any tilde or symbolic link. The path must be writable. If a database does not exist at the path you specify, one will be created automatically.
+
+An offline map database can consume a significant amount of the user’s bandwidth and iCloud storage due to iCloud backups. To exclude the database from backups, set the containing directory’s `NSURLIsExcludedFromBackupKey` resource property to the Boolean value `YES` using the `-[NSURL setResourceValue:forKey:error:]` method. The entire directory will be affected, not just the database file. If the user restores the application from a backup, your application will need to restore any offline packs that had been previously downloaded.
+
+At runtime, you can obtain the value of this key using the `MGLOfflineStorage.databasePath` and `MGLOfflineStorage.databaseURL` properties.
+
 ## MGLCollisionBehaviorPre4_0
 
  If this key is set to YES (`true`), collision detection is performed only between symbol style layers based on the same source, as in versions 2.0–3.7 of the Mapbox Maps SDK for iOS. In other words, symbols in an `MGLSymbolStyleLayer` based on one source (for example, an `MGLShapeSource`) may overlap with symbols in another layer that is based on a different source (such as the Mapbox Streets source). This is the case regardless of the `MGLSymbolStyleLayer.iconAllowsOverlap`, `MGLSymbolStyleLayer.iconIgnoresPlacement`, `MGLSymbolStyleLayer.textAllowsOverlap`, and `MGLSymbolStyleLayer.textIgnoresPlacement` properties.

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -494,7 +494,7 @@ public:
               .withCrossSourceCollisions(enableCrossSourceCollisions);
 
     mbgl::ResourceOptions resourceOptions;
-    resourceOptions.withCachePath([[MGLOfflineStorage sharedOfflineStorage] mbglCachePath])
+    resourceOptions.withCachePath(MGLOfflineStorage.sharedOfflineStorage.databasePath.UTF8String)
                    .withAssetPath([NSBundle mainBundle].resourceURL.path.UTF8String);
 
     NSAssert(!_mbglMap, @"_mbglMap should be NULL");

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -13,12 +13,16 @@
 * Fixed a crash when calling the `-[MGLStyle removeImageForName:]` method with the name of a nonexistent image. ([mapbox/mapbox-gl-native#16391](https://github.com/mapbox/mapbox-gl-native/pull/16391))
 * Fixed an issue where properties such as `MGLFillStyleLayer.fillColor` and `MGLLineStyleLayer.lineColor` misinterpreted non-opaque `NSColor`s. ([#266](https://github.com/mapbox/mapbox-gl-native-ios/pull/266))
 
-### Other changes
+### Offline maps
 
 * Added the `-[MGLOfflinePack setContext:completionHandler:]` method for replacing the data associated with an offline pack, such as a name. ([#288](https://github.com/mapbox/mapbox-gl-native-ios/pull/288))
+* Added the `MGLOfflineStorage.databasePath` and `MGLOfflineStorage.databaseURL` properties. ([#298](https://github.com/mapbox/mapbox-gl-native-ios/pull/298))
+* Fixed an error that occurred if your implementation of the `-[MGLOfflineStorageDelegate offlineStorage:URLForResourceOfKind:]` method returned a local file URL. ([mapbox/mapbox-gl-native#16428](https://github.com/mapbox/mapbox-gl-native/pull/16428)) 
+
+### Other changes
+
 * Fixed a crash when encountering an invalid polyline. ([mapbox/mapbox-gl-native#16409](https://github.com/mapbox/mapbox-gl-native/pull/16409))
 * Fixed an issue where an `MGLMapSnapshotOptions` with an invalid `MGLMapCamera.centerCoordinate`, negative `MGLMapCamera.heading`, negative `MGLMapCamera.pitch`, and negative `MGLMapSnapshotOptions.zoomLevel` resulted in a snapshot centered on Null Island at zoom level 0 even if the style specified a different initial center coordinate or zoom level. ([#280](https://github.com/mapbox/mapbox-gl-native-ios/pull/280))
-* Fixed an error that occurred if your implementation of the `-[MGLOfflineStorageDelegate offlineStorage:URLForResourceOfKind:]` method returned a local file URL. ([mapbox/mapbox-gl-native#16428](https://github.com/mapbox/mapbox-gl-native/pull/16428)) 
 * Certain logging statements no longer run on the main thread. ([mapbox/mapbox-gl-native#16325](https://github.com/mapbox/mapbox-gl-native/pull/16325))
 
 ## 0.15.1

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### Offline maps
 
 * Added the `-[MGLOfflinePack setContext:completionHandler:]` method for replacing the data associated with an offline pack, such as a name. ([#288](https://github.com/mapbox/mapbox-gl-native-ios/pull/288))
-* Added the `MGLOfflineStorage.databasePath` and `MGLOfflineStorage.databaseURL` properties. ([#298](https://github.com/mapbox/mapbox-gl-native-ios/pull/298))
+* Added the `MGLOfflineStorage.databasePath` and `MGLOfflineStorage.databaseURL` properties to obtain the path of the database that contains offline packs and the ambient cache. To customize this path, set the `MGLOfflineStorageDatabasePath` in Info.plist. ([#298](https://github.com/mapbox/mapbox-gl-native-ios/pull/298))
 * Fixed an error that occurred if your implementation of the `-[MGLOfflineStorageDelegate offlineStorage:URLForResourceOfKind:]` method returned a local file URL. ([mapbox/mapbox-gl-native#16428](https://github.com/mapbox/mapbox-gl-native/pull/16428)) 
 
 ### Other changes

--- a/platform/macos/docs/guides/Info.plist Keys.md
+++ b/platform/macos/docs/guides/Info.plist Keys.md
@@ -26,6 +26,16 @@ This key can either be set to a single string or an array of strings, which the 
 
 To disable client-side rendering of CJK characters in favor of [server-side rendering](customizing-fonts.html#server-side-fonts), set this key to the Boolean value `NO`.
 
+## MGLOfflineStorageDatabasePath
+
+This key customizes the file path at which `MGLOfflineStorage` keeps the offline map database, which contains any offline packs as well as the ambient cache. Most applications should not need to customize this path; however, you could customize it to implement a migration path between different versions of your application.
+
+The key is interpreted as either an absolute file path or a file path relative to the main bundle’s resource folder, resolving any tilde or symbolic link. The path must be writable. If a database does not exist at the path you specify, one will be created automatically.
+
+An offline map database can consume a significant amount of the user’s bandwidth and iCloud storage due to iCloud backups. To exclude the database from backups, set the containing directory’s `NSURLIsExcludedFromBackupKey` resource property to the Boolean value `YES` using the `-[NSURL setResourceValue:forKey:error:]` method. The entire directory will be affected, not just the database file. If the user restores the application from a backup, your application will need to restore any offline packs that had been previously downloaded.
+
+At runtime, you can obtain the value of this key using the `MGLOfflineStorage.databasePath` and `MGLOfflineStorage.databaseURL` properties.
+
 ## MGLCollisionBehaviorPre4_0
 
 If this key is set to YES (`true`), collision detection is performed only between symbol style layers based on the same source, as in versions 0.1–0.7 of the Mapbox Maps SDK for iOS. In other words, symbols in an `MGLSymbolStyleLayer` based on one source (for example, an `MGLShapeSource`) may overlap with symbols in another layer that is based on a different source (such as the Mapbox Streets source). This is the case regardless of the `MGLSymbolStyleLayer.iconAllowsOverlap`, `MGLSymbolStyleLayer.iconIgnoresPlacement`, `MGLSymbolStyleLayer.textAllowsOverlap`, and `MGLSymbolStyleLayer.textIgnoresPlacement` properties.

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -293,7 +293,7 @@ public:
               .withCrossSourceCollisions(enableCrossSourceCollisions);
 
     mbgl::ResourceOptions resourceOptions;
-    resourceOptions.withCachePath([[MGLOfflineStorage sharedOfflineStorage] mbglCachePath])
+    resourceOptions.withCachePath(MGLOfflineStorage.sharedOfflineStorage.databasePath.UTF8String)
                    .withAssetPath([NSBundle mainBundle].resourceURL.path.UTF8String);
 
     _mbglMap = std::make_unique<mbgl::Map>(*_rendererFrontend, *_mbglView, mapOptions, resourceOptions);


### PR DESCRIPTION
Added the `MGLOfflineStorage.databasePath` and `MGLOfflineStorage.databaseURL` properties to obtain the path of the database that contains offline packs and the ambient cache, as well as an `MGLOfflineStorageDatabasePath` Info.plist key to customize this path.

Fixes #297.

<!-- `<changelog>Added the `MGLOfflineStorage.databasePath` and `MGLOfflineStorage.databaseURL` properties to obtain the path of the database that contains offline packs and the ambient cache. To customize this path, set the `MGLOfflineStorageDatabasePath` in Info.plist.</changelog>` -->

/cc @mapbox/maps-ios