### PR TITLE
Refactor accessibility calculations

### DIFF
--- a/platform/darwin/src/MGLSignpost.h
+++ b/platform/darwin/src/MGLSignpost.h
@@ -7,21 +7,45 @@
 #define SIGNPOST_CONCAT2(x,y)   x##y
 #define SIGNPOST_CONCAT(x,y)    SIGNPOST_CONCAT2(x,y)
 #define SIGNPOST_NAME(x)        SIGNPOST_CONCAT(signpost,x)
+//
+//#define MGL_EXPORT __attribute__((visibility ("default")))
+//
+//MGL_EXPORT extern os_log_t MGLDefaultSignpostLog;
+//MGL_EXPORT extern os_signpost_id_t MGLDefaultSignpost;
+//
+/**
+ Create an os_log_t (for use with os_signposts) with the "com.mapbox.mapbox" subsystem.
+ 
+ This method checks `NSUserDefaults` for `MGLSignpostsEnabled`, otherwise will return `OS_LOG_DISABLED`.
+ Typically you should add `-MGLSignpostsEnabled YES` as run arguments to the Xcode scheme when
+ profiling.
+ 
+ This is only required if you need to add categories other than the default.
+
+ @param name Name for the log category.
+ @return log object.
+ */
+//MGL_EXPORT extern os_log_t MGLSignpostLogCreate(const char* name);
+
+
+
+//os_log_t log = os_log_create("com.mapbox.mapbox", name);
+//
+//OS_LOG_DISABLED
+
 
 #define MGL_CREATE_SIGNPOST(log) \
     ({ \
         os_signpost_id_t SIGNPOST_NAME(__LINE__) = OS_SIGNPOST_ID_INVALID; \
-        if (log != OS_LOG_DISABLED) { \
-            if (__builtin_available(iOS 12.0, macOS 10.14, *)) { \
-                SIGNPOST_NAME(__LINE__) = os_signpost_id_generate(log); \
-            } \
+        if (__builtin_available(iOS 12.0, macOS 10.14, *)) { \
+            SIGNPOST_NAME(__LINE__) = os_signpost_id_generate(log); \
         } \
         SIGNPOST_NAME(__LINE__); \
     })
 
 #define MGL_SIGNPOST_BEGIN(log, signpost, name, ...) \
     ({ \
-        if ((log != OS_LOG_DISABLED) && (signpost != OS_SIGNPOST_ID_INVALID)) { \
+        if (signpost != OS_SIGNPOST_ID_INVALID) { \
             if (__builtin_available(iOS 12.0, macOS 10.14, *)) { \
                 os_signpost_interval_begin(log, signpost, name, ##__VA_ARGS__); \
             } \
@@ -30,7 +54,7 @@
 
 #define MGL_SIGNPOST_END(log, signpost, name, ...) \
     ({ \
-        if ((log != OS_LOG_DISABLED) && (signpost != OS_SIGNPOST_ID_INVALID)) { \
+        if (signpost != OS_SIGNPOST_ID_INVALID) { \
             if (__builtin_available(iOS 12.0, macOS 10.14, *)) { \
                 os_signpost_interval_end(log, signpost, name, ##__VA_ARGS__); \
             } \
@@ -39,11 +63,30 @@
 
 #define MGL_SIGNPOST_EVENT(log, signpost, name, ...) \
     ({ \
-        if ((log != OS_LOG_DISABLED) && (signpost != OS_SIGNPOST_ID_INVALID)) { \
+        if (signpost != OS_SIGNPOST_ID_INVALID) { \
             if (__builtin_available(iOS 12.0, macOS 10.14, *)) { \
                 os_signpost_event_emit(log, signpost, name, ##__VA_ARGS__); \
             } \
         } \
     })
+
+// Use MGL_SIGNPOST_BEGIN & MGL_SIGNPOST_END around sections of code that you
+// wish to profile.
+// MGL_SIGNPOST_EVENT can be used for single one-off events
+//
+// For example:
+//
+//  os_signpost_id_t signpost = MGL_CREATE_SIGNPOST();
+//  MGL_SIGNPOST_BEGIN(signpost, "example");
+//  [self performAComputationallyExpensiveOperation];
+//  MGL_SIGNPOST_END(signpost, "example", "%d", numberOfWidgets);
+//
+//  MGL_SIGNPOST_EVENT("error", "%d", errorCode);
+//
+//#define MGL_CREATE_SIGNPOST()                     MGL_NAMED_CREATE_SIGNPOST(MGLDefaultSignpostLog)
+//
+//#define MGL_SIGNPOST_BEGIN(signpost, name, ...)   MGL_NAMED_SIGNPOST_BEGIN(MGLDefaultSignpostLog, signpost, name, ##__VA_ARGS__)
+//#define MGL_SIGNPOST_END(signpost, name, ...)     MGL_NAMED_SIGNPOST_END(MGLDefaultSignpostLog, signpost, name, ##__VA_ARGS__)
+//#define MGL_SIGNPOST_EVENT(signpost, name, ...)   MGL_NAMED_SIGNPOST_EVENT(MGLDefaultSignpostLog, signpost, name, ##__VA_ARGS__)
 
 #endif /* MGLSignpost_h */

--- a/platform/ios/Integration Tests/Query Tests/MGLQueryFeatureTests.m
+++ b/platform/ios/Integration Tests/Query Tests/MGLQueryFeatureTests.m
@@ -270,7 +270,8 @@ NSDictionary* MGLTestAccessibilityDictionaryForElement(NSObject* element)
 
     // Recurse
     elementCount = 0;
-    
+
+    // Fails: "NSInvalidArgumentException", "*** -[__NSPlaceholderArray initWithCapacity:]: capacity (9223372036854775807) is ridiculous"
     if (!element.isAccessibilityElement) {
         elementCount = element.accessibilityElementCount;
         NSMutableArray *mutableElements = [NSMutableArray arrayWithCapacity:elementCount];

--- a/platform/ios/Integration Tests/Query Tests/MGLQueryFeatureTests.m
+++ b/platform/ios/Integration Tests/Query Tests/MGLQueryFeatureTests.m
@@ -59,16 +59,8 @@ void writeDictionaryToFile(NSDictionary *info, NSString *filename);
     
     [self queryRoads];
     
-    __block NSDictionary *accessibilityDictionary;
+    NSDictionary *accessibilityDictionary = MGLTestAccessibilityDictionaryForElement(self.mapView);
     
-    os_signpost_id_t signpost = MGL_CREATE_SIGNPOST(self.log);
-
-    [self measureBlock:^{
-        MGL_SIGNPOST_BEGIN(self.log, signpost, "create-dictionary");
-        accessibilityDictionary = MGLTestAccessibilityDictionaryForElement(self.mapView);
-        MGL_SIGNPOST_END(self.log, signpost, "create-dictionary");
-    }];
-        
     NSString *filename = @"testQueryRoadsAroundDC";
 
 #if 0
@@ -79,8 +71,6 @@ void writeDictionaryToFile(NSDictionary *info, NSString *filename);
     XCTAssertNotNil(expected);
     [self assertAccessibilityDictionary:accessibilityDictionary isEqualToDictionary:expected];
 #endif
-    
-    accessibilityDictionary = nil;
 }
 
 #pragma mark - Common methods
@@ -252,7 +242,7 @@ NSArray* MGLTestArrayForBezierPath(UIBezierPath* path)
             
             if (isnan(element->points->x) ||
                 isnan(element->points->y)) {
-                NSCAssert(0, @"Invalid point");
+                NSLog(@"wer");
             }
             
             NSDictionary *elementDict = @{

--- a/platform/ios/Integration Tests/Query Tests/MGLQueryFeatureTests.m
+++ b/platform/ios/Integration Tests/Query Tests/MGLQueryFeatureTests.m
@@ -59,18 +59,25 @@ void writeDictionaryToFile(NSDictionary *info, NSString *filename);
     
     [self queryRoads];
     
-    NSDictionary *accessibilityDictionary = MGLTestAccessibilityDictionaryForElement(self.mapView);
+    __block NSDictionary *accessibilityDictionary;
     
+    os_signpost_id_t signpost = MGL_CREATE_SIGNPOST(self.log);
+
+    [self measureBlock:^{
+        MGL_SIGNPOST_BEGIN(self.log, signpost, "create-dictionary");
+        accessibilityDictionary = MGLTestAccessibilityDictionaryForElement(self.mapView);
+        MGL_SIGNPOST_END(self.log, signpost, "create-dictionary");
+    }];
+        
     NSString *filename = @"testQueryRoadsAroundDC";
 
-#if 0
     writeDictionaryToFile(accessibilityDictionary, [NSString stringWithFormat:@"%@.json", filename]);
-#else
     
     NSDictionary *expected = readAccessibilityDictionaryFromBundle(filename, [NSBundle bundleForClass:[self class]]);
     XCTAssertNotNil(expected);
     [self assertAccessibilityDictionary:accessibilityDictionary isEqualToDictionary:expected];
-#endif
+    
+    accessibilityDictionary = nil;
 }
 
 #pragma mark - Common methods
@@ -242,7 +249,7 @@ NSArray* MGLTestArrayForBezierPath(UIBezierPath* path)
             
             if (isnan(element->points->x) ||
                 isnan(element->points->y)) {
-                NSLog(@"wer");
+                NSCAssert(0, @"Invalid point");
             }
             
             NSDictionary *elementDict = @{

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -130,8 +130,8 @@
 		353D23961D0B0DFE002BE09D /* MGLAnnotationViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 353D23951D0B0DFE002BE09D /* MGLAnnotationViewTests.m */; };
 		354B83961D2E873E005D9406 /* MGLUserLocationAnnotationView.h in Headers */ = {isa = PBXBuildFile; fileRef = 354B83941D2E873E005D9406 /* MGLUserLocationAnnotationView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		354B83971D2E873E005D9406 /* MGLUserLocationAnnotationView.h in Headers */ = {isa = PBXBuildFile; fileRef = 354B83941D2E873E005D9406 /* MGLUserLocationAnnotationView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		354B83981D2E873E005D9406 /* MGLUserLocationAnnotationView.m in Sources */ = {isa = PBXBuildFile; fileRef = 354B83951D2E873E005D9406 /* MGLUserLocationAnnotationView.m */; };
-		354B83991D2E873E005D9406 /* MGLUserLocationAnnotationView.m in Sources */ = {isa = PBXBuildFile; fileRef = 354B83951D2E873E005D9406 /* MGLUserLocationAnnotationView.m */; };
+		354B83981D2E873E005D9406 /* MGLUserLocationAnnotationView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 354B83951D2E873E005D9406 /* MGLUserLocationAnnotationView.mm */; };
+		354B83991D2E873E005D9406 /* MGLUserLocationAnnotationView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 354B83951D2E873E005D9406 /* MGLUserLocationAnnotationView.mm */; };
 		354B839C1D2E9B48005D9406 /* MBXUserLocationAnnotationView.m in Sources */ = {isa = PBXBuildFile; fileRef = 354B839B1D2E9B48005D9406 /* MBXUserLocationAnnotationView.m */; };
 		3557F7B01E1D27D300CCA5E6 /* MGLDistanceFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3557F7AE1E1D27D300CCA5E6 /* MGLDistanceFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3557F7B21E1D27D300CCA5E6 /* MGLDistanceFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 3557F7AF1E1D27D300CCA5E6 /* MGLDistanceFormatter.m */; };
@@ -867,7 +867,7 @@
 		353BAEF51D646370009A8DA9 /* amsterdam.geojson */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = amsterdam.geojson; path = ../../darwin/test/amsterdam.geojson; sourceTree = "<group>"; };
 		353D23951D0B0DFE002BE09D /* MGLAnnotationViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLAnnotationViewTests.m; sourceTree = "<group>"; };
 		354B83941D2E873E005D9406 /* MGLUserLocationAnnotationView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLUserLocationAnnotationView.h; sourceTree = "<group>"; };
-		354B83951D2E873E005D9406 /* MGLUserLocationAnnotationView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLUserLocationAnnotationView.m; sourceTree = "<group>"; };
+		354B83951D2E873E005D9406 /* MGLUserLocationAnnotationView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLUserLocationAnnotationView.mm; sourceTree = "<group>"; };
 		354B839A1D2E9B48005D9406 /* MBXUserLocationAnnotationView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBXUserLocationAnnotationView.h; sourceTree = "<group>"; };
 		354B839B1D2E9B48005D9406 /* MBXUserLocationAnnotationView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MBXUserLocationAnnotationView.m; sourceTree = "<group>"; };
 		3557F7AE1E1D27D300CCA5E6 /* MGLDistanceFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLDistanceFormatter.h; sourceTree = "<group>"; };
@@ -2266,7 +2266,7 @@
 				DA88484C1CBAFB9800AB86E3 /* MGLUserLocation.m */,
 				359F57451D2FDBD5005217F1 /* MGLUserLocationAnnotationView_Private.h */,
 				354B83941D2E873E005D9406 /* MGLUserLocationAnnotationView.h */,
-				354B83951D2E873E005D9406 /* MGLUserLocationAnnotationView.m */,
+				354B83951D2E873E005D9406 /* MGLUserLocationAnnotationView.mm */,
 				966FCF501F3C321000F2B6DE /* MGLUserLocationHeadingArrowLayer.h */,
 				966FCF511F3C321000F2B6DE /* MGLUserLocationHeadingArrowLayer.m */,
 				966FCF4A1F3A5C9200F2B6DE /* MGLUserLocationHeadingBeamLayer.h */,
@@ -3158,7 +3158,7 @@
 				3510FFEC1D6D9C7A00F413B2 /* NSComparisonPredicate+MGLAdditions.mm in Sources */,
 				DAED38651D62D0FC00D7640F /* NSURL+MGLAdditions.m in Sources */,
 				9620BB3A1E69FE1700705A1D /* MGLSDKUpdateChecker.mm in Sources */,
-				354B83981D2E873E005D9406 /* MGLUserLocationAnnotationView.m in Sources */,
+				354B83981D2E873E005D9406 /* MGLUserLocationAnnotationView.mm in Sources */,
 				DA88485D1CBAFB9800AB86E3 /* MGLFaux3DUserLocationAnnotationView.m in Sources */,
 				DAD165701CF41981001FF4B9 /* MGLFeature.mm in Sources */,
 				30E578191DAA855E0050F07E /* UIImage+MGLAdditions.mm in Sources */,
@@ -3256,7 +3256,7 @@
 			files = (
 				35136D3A1D42271A00C20EFD /* MGLBackgroundStyleLayer.mm in Sources */,
 				3510FFED1D6D9C7A00F413B2 /* NSComparisonPredicate+MGLAdditions.mm in Sources */,
-				354B83991D2E873E005D9406 /* MGLUserLocationAnnotationView.m in Sources */,
+				354B83991D2E873E005D9406 /* MGLUserLocationAnnotationView.mm in Sources */,
 				9620BB3B1E69FE1700705A1D /* MGLSDKUpdateChecker.mm in Sources */,
 				DAA4E4221CBB730400178DFB /* MGLPointAnnotation.mm in Sources */,
 				DAED38661D62D0FC00D7640F /* NSURL+MGLAdditions.m in Sources */,

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -3122,7 +3122,7 @@
 				1F95931D1E6DE2E900D5B294 /* MGLNSDateAdditionsTests.mm in Sources */,
 				DA695426215B1E76002041A4 /* MGLMapCameraTests.m in Sources */,
 				96381C0222C6F3950053497D /* MGLMapViewPitchTests.m in Sources */,
-				CA8FBC0921A47BB100D1203C /* MGLRendererConfigurationTests.mm in Sources */,
+				CA8FBC0921A47BB100D1203C /* MGLRendererConfigurationTests.m in Sources */,
 				CAD9D0AA22A86D6F001B25EE /* MGLResourceTests.mm in Sources */,
 				DD58A4C61D822BD000E1F038 /* MGLExpressionTests.mm in Sources */,
 				3575798B1D502B0C000B822E /* MGLBackgroundStyleLayerTests.mm in Sources */,

--- a/platform/ios/ios.xcodeproj/xcshareddata/xcbaselines/16376B061FFD9DAF0000563E.xcbaseline/491B7610-4299-4667-8EB4-F0F9753EBC16.plist
+++ b/platform/ios/ios.xcodeproj/xcshareddata/xcbaselines/16376B061FFD9DAF0000563E.xcbaseline/491B7610-4299-4667-8EB4-F0F9753EBC16.plist
@@ -11,9 +11,9 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.63731</real>
+					<real>0.11232</real>
 					<key>baselineIntegrationDisplayName</key>
-					<string>Jun 14, 2020 at 3:24:48 PM</string>
+					<string>Jun 15, 2020 at 12:15:03 AM</string>
 				</dict>
 			</dict>
 			<key>testQueryRoadsPerformanceAroundDC🔒</key>
@@ -21,9 +21,9 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.052211</real>
+					<real>0.052153</real>
 					<key>baselineIntegrationDisplayName</key>
-					<string>Jun 14, 2020 at 3:12:22 PM</string>
+					<string>Jun 15, 2020 at 12:15:03 AM</string>
 				</dict>
 			</dict>
 		</dict>

--- a/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/Integration Test Harness.xcscheme
+++ b/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/Integration Test Harness.xcscheme
@@ -36,6 +36,13 @@
             ReferencedContainer = "container:ios.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "MAPBOX_ACCESS_TOKEN"
+            value = "pk.eyJ1IjoianVsaWFucmV4IiwiYSI6ImNrMGp2N3k3ZzAwbWkzbnMzcG1zZ291cmkifQ.6Fv-dxHmzcqHHm_Tlf3x6A"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3151,7 +3151,7 @@ public:
     
     // Let the annotation view serve as its own accessibility element.
     MGLAnnotationView *annotationView = annotationContext.annotationView;
-    if (annotationView)//asdf && annotationView.superview)
+    if (annotationView && annotationView.superview)
     {
         return annotationView;
     }

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2933,12 +2933,14 @@ public:
     
     // Places
     NSArray *sortedPlaceFeatures = nil;
-    
+    NSArray *visiblePlaceFeatures;
     if (!_sortedVisiblePlaceElements) {
         
         MGL_SIGNPOST_BEGIN(self.log, signpost, "gae/query-places");
         NSArray *placeStyleLayerIdentifiers = [self.style.placeStyleLayers valueForKey:@"identifier"];
-        NSArray *visiblePlaceFeatures = [self visibleFeaturesInRect:bounds inStyleLayersWithIdentifiers:[NSSet setWithArray:placeStyleLayerIdentifiers]];
+        
+        // TODO:
+        /*NSArray **/visiblePlaceFeatures = [self visibleFeaturesInRect:bounds inStyleLayersWithIdentifiers:[NSSet setWithArray:placeStyleLayerIdentifiers]];
         MGL_SIGNPOST_END(self.log, signpost, "gae/query-places");
 
         
@@ -2972,7 +2974,6 @@ public:
     NSUInteger numberOfPlaces = _sortedVisiblePlaceElements.count;
     
     // Roads
-    
     if (!_sortedVisibleRoadElements) {
         MGL_SIGNPOST_BEGIN(self.log, signpost, "gae/query-roads");
         NSArray *roadStyleLayerIdentifiers = [self.style.roadStyleLayers valueForKey:@"identifier"];
@@ -3029,7 +3030,8 @@ public:
     {
         MGL_SIGNPOST_BEGIN(self.log, signpost, "gae/build-elements");
 
-        BOOL compassViewVisible       = self.compassView.alpha > 0.0;
+        // TODO: Previously, accessibility considered the compass always visible
+        BOOL compassViewVisible       = YES;//self.compassView.alpha > 0.0;
         BOOL userLocationViewVisible  = self.userLocationAnnotationView && !self.userLocationAnnotationView.isHidden;
         BOOL attributionButtonVisible = self.attributionButton && !self.attributionButton.isHidden;
         
@@ -3083,8 +3085,9 @@ public:
         if (numberOfPlaces > 0) {
             NSMutableArray *placesArray = [NSMutableArray arrayWithCapacity:4];
             NSMutableSet *placesSet = [NSMutableSet setWithCapacity:numberOfPlaces];
-            
-            for (id <MGLFeature> placeFeature in sortedPlaceFeatures) {
+            // TODO:
+//          for (id <MGLFeature> placeFeature in sortedPlaceFeatures){
+            for (id <MGLFeature> placeFeature in visiblePlaceFeatures.reverseObjectEnumerator){
                 NSString *name = [placeFeature attributeForKey:@"name"];
                 if (![placesSet containsObject:name]) {
                     [placesArray addObject:name];

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2938,9 +2938,8 @@ public:
         
         MGL_SIGNPOST_BEGIN(self.log, signpost, "gae/query-places");
         NSArray *placeStyleLayerIdentifiers = [self.style.placeStyleLayers valueForKey:@"identifier"];
-        
-        // TODO:
-        /*NSArray **/visiblePlaceFeatures = [self visibleFeaturesInRect:bounds inStyleLayersWithIdentifiers:[NSSet setWithArray:placeStyleLayerIdentifiers]];
+
+        visiblePlaceFeatures = [self visibleFeaturesInRect:bounds inStyleLayersWithIdentifiers:[NSSet setWithArray:placeStyleLayerIdentifiers]];
         MGL_SIGNPOST_END(self.log, signpost, "gae/query-places");
 
         
@@ -3011,10 +3010,8 @@ public:
     // If there's a selected annotation with a callout view that's visible, then
     // we use those (regardless of whether we've just calculated our roads/places
     // as those are used by the accessibility value.
-    
-    // TODO: check this assumption
-    
-    if (self.calloutViewForSelectedAnnotation.superview != nil) // might not be true at this point in time
+
+    if (self.calloutViewForSelectedAnnotation.superview != nil)
     {
         // Update the accessibility path
         UIBezierPath *calloutViewPath = [UIBezierPath bezierPathWithRect:self.calloutViewForSelectedAnnotation.frame];
@@ -3030,8 +3027,7 @@ public:
     {
         MGL_SIGNPOST_BEGIN(self.log, signpost, "gae/build-elements");
 
-        // TODO: Previously, accessibility considered the compass always visible
-        BOOL compassViewVisible       = YES;//self.compassView.alpha > 0.0;
+        BOOL compassViewVisible       = self.compassView.alpha > 0.0 || !self.compassView.isHidden;
         BOOL userLocationViewVisible  = self.userLocationAnnotationView && !self.userLocationAnnotationView.isHidden;
         BOOL attributionButtonVisible = self.attributionButton && !self.attributionButton.isHidden;
         
@@ -3085,9 +3081,8 @@ public:
         if (numberOfPlaces > 0) {
             NSMutableArray *placesArray = [NSMutableArray arrayWithCapacity:4];
             NSMutableSet *placesSet = [NSMutableSet setWithCapacity:numberOfPlaces];
-            // TODO:
-//          for (id <MGLFeature> placeFeature in sortedPlaceFeatures){
-            for (id <MGLFeature> placeFeature in visiblePlaceFeatures.reverseObjectEnumerator){
+
+          for (id <MGLFeature> placeFeature in sortedPlaceFeatures){
                 NSString *name = [placeFeature attributeForKey:@"name"];
                 if (![placesSet containsObject:name]) {
                     [placesArray addObject:name];
@@ -3129,11 +3124,6 @@ public:
     }
     
     MGLAssert(NO, @"Index %ld not in recognized accessibility element ranges. ", (long)index);
-//              @"User location annotation range: %@; visible annotation range: %@; "
-//              @"visible place feature range: %@; visible road feature range: %@.",
-//              (long)index, NSStringFromRange(userLocationAnnotationRange),
-//              NSStringFromRange(visibleAnnotationRange), NSStringFromRange(visiblePlaceFeatureRange),
-//              NSStringFromRange(visibleRoadFeatureRange));
     return nil;
 }
 

--- a/platform/ios/src/MGLMapView_Private.h
+++ b/platform/ios/src/MGLMapView_Private.h
@@ -65,6 +65,9 @@ FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const _Nonnull MGLUnderlyingMapUna
 
 - (void)pauseRendering:(nonnull NSNotification *)notification;
 - (void)resumeRendering:(nonnull NSNotification *)notification;
+
+- (void)accessibilityPostNotification:(UIAccessibilityNotifications)notification argument:(__nullable id)argument;
+
 @property (nonatomic, nonnull) MGLUserLocationAnnotationView *userLocationAnnotationView;
 @property (nonatomic, nonnull) MGLAnnotationContainerView *annotationContainerView;
 @property (nonatomic, readonly) BOOL enablePresentsWithTransaction;

--- a/platform/ios/src/MGLUserLocationAnnotationView.mm
+++ b/platform/ios/src/MGLUserLocationAnnotationView.mm
@@ -5,6 +5,7 @@
 #import "MGLAnnotationView_Private.h"
 #import "MGLAnnotation.h"
 #import "MGLMapView.h"
+#import "MGLMapView_Private.h"
 #import "MGLCoordinateFormatter.h"
 #import "NSBundle+MGLAdditions.h"
 
@@ -93,7 +94,7 @@
     [super setHidden:hidden];
     if (oldValue != hidden)
     {
-        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil);
+        [self.mapView accessibilityPostNotification:UIAccessibilityLayoutChangedNotification argument:nil];
     }
 }
 


### PR DESCRIPTION
This is part 2 of 3 PRs that port https://github.com/mapbox/mapbox-gl-native/pull/15303 to this repo. (See also #317, #319.)

This PR, refactors the accessibility element calculations, caching the results. Previously these were needlessly being called continually. This PR addresses the performance concerns. In addition, I have seen fewer crashes.

Fixes https://github.com/mapbox/mapbox-gl-native-ios/issues/220.

