### PR TITLE
Add accessiblePlaceSourceIdentifiers to make layers available to VoiceOver

### DIFF
--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -265,11 +265,11 @@ MGL_EXPORT
 
 // TODO: Docs
 /**
- A set containing the custom source layer identifiers for place features available for accessibility. These features must have a `name` attribute.
-
- This set does not include place or road source identifiers included by default.
- */
-@property (nonatomic) NSSet *accessiblePlaceSourceLayerIdentifiers;
+A set containing user-specified source identifiers for point features available for accessibility. The point features must have a `name` attribute and belong to a `MGLVectorStyleLayer`.
+ 
+This set does not include Mapbox source identifiers included by default.
+*/
+@property (nonatomic) NSSet *accessiblePlaceSourceIdentifiers;
 
 /**
  Returns a source with the given identifier in the current style.

--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -265,11 +265,11 @@ MGL_EXPORT
 @property (nonatomic, assign) BOOL performsPlacementTransitions;
 
 /**
-A set containing user-specified source identifiers for point features available for accessibility. The point features must have a `name` attribute that matches those specified by <a href="https://www.mapbox.com/vector-tiles/mapbox-streets-v8/#overview">Mapbox Streets</a> source and belong to a `MGLVectorStyleLayer`.
+A set containing user-specified source layer identifiers for point features available for accessibility. The features should have a `MGLVectorTileSource` The point features must have a `name` attribute that matches those specified by <a href="https://www.mapbox.com/vector-tiles/mapbox-streets-v8/#overview">Mapbox Streets</a> source and belong to a `MGLVectorStyleLayer`.
  
-This set does not include Mapbox Streets source identifiers included by default.
+This set does not include Mapbox Streets source identifiers, which are included by default.
 */
-@property (nonatomic) NSSet *accessiblePlaceSourceIdentifiers;
+@property (nonatomic) NSSet <NSString *> *accessiblePlaceSourceLayerIdentifiers;
 
 /**
  Returns a source with the given identifier in the current style.

--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -263,11 +263,10 @@ MGL_EXPORT
  */
 @property (nonatomic, assign) BOOL performsPlacementTransitions;
 
-// TODO: Docs
 /**
-A set containing user-specified source identifiers for point features available for accessibility. The point features must have a `name` attribute and belong to a `MGLVectorStyleLayer`.
+A set containing user-specified source identifiers for point features available for accessibility. The point features must have a `name` attribute that matches those specified by <a href="https://www.mapbox.com/vector-tiles/mapbox-streets-v8/#overview">Mapbox Streets</a> source and belong to a `MGLVectorStyleLayer`.
  
-This set does not include Mapbox source identifiers included by default.
+This set does not include Mapbox Streets source identifiers included by default.
 */
 @property (nonatomic) NSSet *accessiblePlaceSourceIdentifiers;
 

--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -243,6 +243,7 @@ MGL_EXPORT
  */
 @property (readonly, copy, nullable) NSString *name;
 
+
 #pragma mark Managing Sources
 
 /**

--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -265,7 +265,7 @@ MGL_EXPORT
 @property (nonatomic, assign) BOOL performsPlacementTransitions;
 
 /**
-A set containing user-specified source layer identifiers for point features available for accessibility. The features should have a `MGLVectorTileSource` The point features must have a `name` attribute that matches those specified by <a href="https://www.mapbox.com/vector-tiles/mapbox-streets-v8/#overview">Mapbox Streets</a> source and belong to a `MGLVectorStyleLayer`.
+A set containing user-specified source layer identifiers for point features available for accessibility. The features should have a `MGLVectorTileSource` and belong to a source layer. The point features must have a `name` attribute that matches those specified by <a href="https://www.mapbox.com/vector-tiles/mapbox-streets-v8/#overview">Mapbox Streets</a> source and belong to a `MGLVectorStyleLayer`.
  
 This set does not include Mapbox Streets source identifiers, which are included by default.
 */

--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -263,6 +263,14 @@ MGL_EXPORT
  */
 @property (nonatomic, assign) BOOL performsPlacementTransitions;
 
+// TODO: Docs
+/**
+ A set containing the custom source layer identifiers for place features available for accessibility. These features must have a `name` attribute.
+
+ This set does not include place or road source identifiers included by default.
+ */
+@property (nonatomic) NSSet *accessiblePlaceSourceLayerIdentifiers;
+
 /**
  Returns a source with the given identifier in the current style.
 
@@ -330,7 +338,6 @@ MGL_EXPORT
  an `NSError` object describing the problem.
  */
 - (BOOL)removeSource:(MGLSource *)source error:(NSError * __nullable * __nullable)outError;
-
 
 #pragma mark Managing Style Layers
 

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -121,7 +121,7 @@ MGL_DEFINE_STYLE(satelliteStreets, satellite-streets)
 static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
               "mbgl::util::default_styles::orderedStyles and MGLStyle have different numbers of styles.");
 
-@synthesize accessiblePlaceSourceLayerIdentifiers = _accessiblePlaceSourceLayerIdentifiers;
+@synthesize accessiblePlaceSourceIdentifiers = _accessiblePlaceSourceIdentifiers;
 
 #pragma mark -
 
@@ -626,25 +626,25 @@ static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
     }];
 }
 
-- (void)setAccessiblePlaceSourceLayerIdentifiers:(NSSet *)accessiblePlaceSourceLayerIdentifiers {
-    if (![_accessiblePlaceSourceLayerIdentifiers isEqualToSet:accessiblePlaceSourceLayerIdentifiers]) {
-        _accessiblePlaceSourceLayerIdentifiers = accessiblePlaceSourceLayerIdentifiers;
+- (void)setAccessiblePlaceSourceIdentifiers:(NSSet *)accessiblePlaceSourceLayerIdentifiers {
+    if (![_accessiblePlaceSourceIdentifiers isEqualToSet:accessiblePlaceSourceLayerIdentifiers]) {
+        _accessiblePlaceSourceIdentifiers = accessiblePlaceSourceLayerIdentifiers;
     }
 }
 
-- (NSSet *)accessiblePlaceSourceLayerIdentifiers {
-    return _accessiblePlaceSourceLayerIdentifiers;
+- (NSSet *)accessiblePlaceSourceIdentifiers {
+    return _accessiblePlaceSourceIdentifiers;
 }
 
 - (NSArray<MGLStyleLayer *> *)placeStyleLayers {
     NSSet *streetsSourceIdentifiers = [self.mapboxStreetsSources valueForKey:@"identifier"];
     NSSet *placeSourceLayerIdentifiers = [NSSet setWithObjects:@"marine_label", @"country_label", @"state_label", @"place_label", @"water_label", @"poi_label", @"rail_station_label", @"mountain_peak_label", @"natural_label", @"transit_stop_label", nil];
-    if (self.accessiblePlaceSourceLayerIdentifiers == nil) {
-        _accessiblePlaceSourceLayerIdentifiers = [NSMutableSet set];
+    if (self.accessiblePlaceSourceIdentifiers == nil) {
+        _accessiblePlaceSourceIdentifiers = [NSMutableSet set];
     }
 
     NSPredicate *isPlacePredicate = [NSPredicate predicateWithBlock:^BOOL (MGLVectorStyleLayer * _Nullable layer, NSDictionary<NSString *, id> * _Nullable bindings) {
-        return [layer isKindOfClass:[MGLVectorStyleLayer class]] && (([streetsSourceIdentifiers containsObject:layer.sourceIdentifier] && [placeSourceLayerIdentifiers containsObject:layer.sourceLayerIdentifier]) || [self.accessiblePlaceSourceLayerIdentifiers containsObject:layer.sourceIdentifier]);
+        return [layer isKindOfClass:[MGLVectorStyleLayer class]] && (([streetsSourceIdentifiers containsObject:layer.sourceIdentifier] && [placeSourceLayerIdentifiers containsObject:layer.sourceLayerIdentifier]) || [self.accessiblePlaceSourceIdentifiers containsObject:layer.sourceIdentifier]);
     }];
     return [self.layers filteredArrayUsingPredicate:isPlacePredicate];
 }

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -122,8 +122,6 @@ MGL_DEFINE_STYLE(satelliteStreets, satellite-streets)
 static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
               "mbgl::util::default_styles::orderedStyles and MGLStyle have different numbers of styles.");
 
-@synthesize accessiblePlaceSourceIdentifiers = _accessiblePlaceSourceIdentifiers;
-
 #pragma mark -
 
 - (instancetype)initWithRawStyle:(mbgl::style::Style *)rawStyle stylable:(id <MGLStylable>)stylable {
@@ -627,26 +625,16 @@ static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
     }];
 }
 
-- (void)setAccessiblePlaceSourceIdentifiers:(NSSet *)accessiblePlaceSourceLayerIdentifiers {
-    if (![_accessiblePlaceSourceIdentifiers isEqualToSet:accessiblePlaceSourceLayerIdentifiers]) {
-        _accessiblePlaceSourceIdentifiers = accessiblePlaceSourceLayerIdentifiers;
-    }
-}
-
-- (NSSet *)accessiblePlaceSourceIdentifiers {
-    return _accessiblePlaceSourceIdentifiers;
-}
-
 - (NSArray<MGLStyleLayer *> *)placeStyleLayers {
     NSSet *streetsSourceIdentifiers = [self.mapboxStreetsSources valueForKey:@"identifier"];
 
     NSSet *placeSourceLayerIdentifiers = [NSSet setWithObjects:@"marine_label", @"country_label", @"state_label", @"place_label", @"water_label", @"poi_label", @"rail_station_label", @"mountain_peak_label", @"natural_label", @"transit_stop_label", nil];
-    if (self.accessiblePlaceSourceIdentifiers == nil) {
-        _accessiblePlaceSourceIdentifiers = [NSMutableSet set];
+    if (self.accessiblePlaceSourceLayerIdentifiers == nil) {
+        _accessiblePlaceSourceLayerIdentifiers = [NSMutableSet set];
     }
 
     NSPredicate *isPlacePredicate = [NSPredicate predicateWithBlock:^BOOL (MGLVectorStyleLayer * _Nullable layer, NSDictionary<NSString *, id> * _Nullable bindings) {
-        return [layer isKindOfClass:[MGLVectorStyleLayer class]] && (([streetsSourceIdentifiers containsObject:layer.sourceIdentifier] && [placeSourceLayerIdentifiers containsObject:layer.sourceLayerIdentifier]) || [self.accessiblePlaceSourceIdentifiers containsObject:layer.sourceIdentifier]);
+        return [layer isKindOfClass:[MGLVectorStyleLayer class]] && (([streetsSourceIdentifiers containsObject:layer.sourceIdentifier] && [placeSourceLayerIdentifiers containsObject:layer.sourceLayerIdentifier]) || [self.accessiblePlaceSourceLayerIdentifiers containsObject:layer.sourceLayerIdentifier]);
     }];
     return [self.layers filteredArrayUsingPredicate:isPlacePredicate];
 }

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -87,7 +87,6 @@ const MGLExceptionName MGLRedundantSourceIdentifierException = @"MGLRedundantSou
 @property (readonly, copy, nullable) NSURL *URL;
 @property (nonatomic, readwrite, strong) NSMutableDictionary<NSString *, MGLOpenGLStyleLayer *> *openGLLayers;
 @property (nonatomic) NSMutableDictionary<NSString *, NSDictionary<NSObject *, MGLTextLanguage *> *> *localizedLayersByIdentifier;
-
 @end
 
 @implementation MGLStyle
@@ -121,6 +120,8 @@ MGL_DEFINE_STYLE(satelliteStreets, satellite-streets)
 // are defined above and also declared in MGLStyle.h.
 static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
               "mbgl::util::default_styles::orderedStyles and MGLStyle have different numbers of styles.");
+
+@synthesize accessiblePlaceSourceLayerIdentifiers = _accessiblePlaceSourceLayerIdentifiers;
 
 #pragma mark -
 
@@ -625,12 +626,25 @@ static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
     }];
 }
 
+- (void)setAccessiblePlaceSourceLayerIdentifiers:(NSSet *)accessiblePlaceSourceLayerIdentifiers {
+    if (![_accessiblePlaceSourceLayerIdentifiers isEqualToSet:accessiblePlaceSourceLayerIdentifiers]) {
+        _accessiblePlaceSourceLayerIdentifiers = accessiblePlaceSourceLayerIdentifiers;
+    }
+}
+
+- (NSSet *)accessiblePlaceSourceLayerIdentifiers {
+    return _accessiblePlaceSourceLayerIdentifiers;
+}
+
 - (NSArray<MGLStyleLayer *> *)placeStyleLayers {
     NSSet *streetsSourceIdentifiers = [self.mapboxStreetsSources valueForKey:@"identifier"];
-    
     NSSet *placeSourceLayerIdentifiers = [NSSet setWithObjects:@"marine_label", @"country_label", @"state_label", @"place_label", @"water_label", @"poi_label", @"rail_station_label", @"mountain_peak_label", @"natural_label", @"transit_stop_label", nil];
+    if (self.accessiblePlaceSourceLayerIdentifiers == nil) {
+        _accessiblePlaceSourceLayerIdentifiers = [NSMutableSet set];
+    }
+
     NSPredicate *isPlacePredicate = [NSPredicate predicateWithBlock:^BOOL (MGLVectorStyleLayer * _Nullable layer, NSDictionary<NSString *, id> * _Nullable bindings) {
-        return [layer isKindOfClass:[MGLVectorStyleLayer class]] && [streetsSourceIdentifiers containsObject:layer.sourceIdentifier] && [placeSourceLayerIdentifiers containsObject:layer.sourceLayerIdentifier];
+        return [layer isKindOfClass:[MGLVectorStyleLayer class]] && (([streetsSourceIdentifiers containsObject:layer.sourceIdentifier] && [placeSourceLayerIdentifiers containsObject:layer.sourceLayerIdentifier]) || [self.accessiblePlaceSourceLayerIdentifiers containsObject:layer.sourceIdentifier]);
     }];
     return [self.layers filteredArrayUsingPredicate:isPlacePredicate];
 }

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -87,6 +87,7 @@ const MGLExceptionName MGLRedundantSourceIdentifierException = @"MGLRedundantSou
 @property (readonly, copy, nullable) NSURL *URL;
 @property (nonatomic, readwrite, strong) NSMutableDictionary<NSString *, MGLOpenGLStyleLayer *> *openGLLayers;
 @property (nonatomic) NSMutableDictionary<NSString *, NSDictionary<NSObject *, MGLTextLanguage *> *> *localizedLayersByIdentifier;
+
 @end
 
 @implementation MGLStyle
@@ -638,6 +639,7 @@ static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
 
 - (NSArray<MGLStyleLayer *> *)placeStyleLayers {
     NSSet *streetsSourceIdentifiers = [self.mapboxStreetsSources valueForKey:@"identifier"];
+
     NSSet *placeSourceLayerIdentifiers = [NSSet setWithObjects:@"marine_label", @"country_label", @"state_label", @"place_label", @"water_label", @"poi_label", @"rail_station_label", @"mountain_peak_label", @"natural_label", @"transit_stop_label", nil];
     if (self.accessiblePlaceSourceIdentifiers == nil) {
         _accessiblePlaceSourceIdentifiers = [NSMutableSet set];

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## master
+
+* * Added the `MGLStyle.accessiblePlaceSourceLayerIdentifiers` property to cause VoiceOver to read aloud certain layers in `MGLVectorTileSource`s as places, the same way that certain layers in the Mapbox Streets source are already read aloud as places. ([#336](https://github.com/mapbox/mapbox-gl-native-ios/pull/336))
+
 ## 6.0.0
  
 This major release does not include any breaking changes to public APIs. We are treating this release as a SEMVER major change because our installation instructions have changed. 

--- a/platform/ios/src/MGLMapAccessibilityElement.mm
+++ b/platform/ios/src/MGLMapAccessibilityElement.mm
@@ -62,7 +62,9 @@
         // may be in the local language, which may be written in another script.
         // Attempt to transform to the script of the preferred language, keeping
         // the original string if no transform exists or if transformation fails.
-        dominantScript = [NSOrthography mgl_dominantScriptForMapboxStreetsLanguage:languageCode];
+        if (!dominantScript) {
+            dominantScript = [NSOrthography mgl_dominantScriptForMapboxStreetsLanguage:languageCode];
+        }
         name = [name mgl_stringByTransliteratingIntoScript:dominantScript];
 
         self.accessibilityLabel = name;

--- a/platform/ios/src/MGLMapAccessibilityElement.mm
+++ b/platform/ios/src/MGLMapAccessibilityElement.mm
@@ -52,15 +52,16 @@
         NSString *nameAttribute = [NSString stringWithFormat:@"name_%@", languageCode];
         NSString *name = [feature attributeForKey:nameAttribute];
 
-        if (name == nil && [feature attributeForKey:@"name"] != nil) {
-            name = [feature attributeForKey:@"name"];
-        }
         // If a feature hasn’t been translated into the preferred language, it
         // may be in the local language, which may be written in another script.
         // Attempt to transform to the script of the preferred language, keeping
         // the original string if no transform exists or if transformation fails.
         NSString *dominantScript = [NSOrthography mgl_dominantScriptForMapboxStreetsLanguage:languageCode];
         name = [name mgl_stringByTransliteratingIntoScript:dominantScript];
+
+        if (name == nil && [feature attributeForKey:@"name"] != nil) {
+            name = [feature attributeForKey:@"name"];
+        }
 
         self.accessibilityLabel = name;
     }

--- a/platform/ios/src/MGLMapAccessibilityElement.mm
+++ b/platform/ios/src/MGLMapAccessibilityElement.mm
@@ -52,12 +52,16 @@
         NSString *nameAttribute = [NSString stringWithFormat:@"name_%@", languageCode];
         NSString *name = [feature attributeForKey:nameAttribute];
 
+        if (name == nil && [feature attributeForKey:@"name"] != nil) {
+            name = [feature attributeForKey:@"name"];
+        }
         // If a feature hasn’t been translated into the preferred language, it
         // may be in the local language, which may be written in another script.
         // Attempt to transform to the script of the preferred language, keeping
         // the original string if no transform exists or if transformation fails.
         NSString *dominantScript = [NSOrthography mgl_dominantScriptForMapboxStreetsLanguage:languageCode];
         name = [name mgl_stringByTransliteratingIntoScript:dominantScript];
+
 
         self.accessibilityLabel = name;
     }

--- a/platform/ios/src/MGLMapAccessibilityElement.mm
+++ b/platform/ios/src/MGLMapAccessibilityElement.mm
@@ -62,7 +62,6 @@
         NSString *dominantScript = [NSOrthography mgl_dominantScriptForMapboxStreetsLanguage:languageCode];
         name = [name mgl_stringByTransliteratingIntoScript:dominantScript];
 
-
         self.accessibilityLabel = name;
     }
     return self;

--- a/platform/ios/src/MGLMapAccessibilityElement.mm
+++ b/platform/ios/src/MGLMapAccessibilityElement.mm
@@ -52,16 +52,17 @@
         NSString *nameAttribute = [NSString stringWithFormat:@"name_%@", languageCode];
         NSString *name = [feature attributeForKey:nameAttribute];
 
+        if (name == nil && [feature attributeForKey:@"name"] != nil) {
+            name = [feature attributeForKey:@"name"];
+            languageCode = [feature attributeForKey:@"name_script"];
+        }
+
         // If a feature hasn’t been translated into the preferred language, it
         // may be in the local language, which may be written in another script.
         // Attempt to transform to the script of the preferred language, keeping
         // the original string if no transform exists or if transformation fails.
         NSString *dominantScript = [NSOrthography mgl_dominantScriptForMapboxStreetsLanguage:languageCode];
         name = [name mgl_stringByTransliteratingIntoScript:dominantScript];
-
-        if (name == nil && [feature attributeForKey:@"name"] != nil) {
-            name = [feature attributeForKey:@"name"];
-        }
 
         self.accessibilityLabel = name;
     }

--- a/platform/ios/src/MGLMapAccessibilityElement.mm
+++ b/platform/ios/src/MGLMapAccessibilityElement.mm
@@ -52,16 +52,17 @@
         NSString *nameAttribute = [NSString stringWithFormat:@"name_%@", languageCode];
         NSString *name = [feature attributeForKey:nameAttribute];
 
+        NSString *dominantScript;
         if (name == nil && [feature attributeForKey:@"name"] != nil) {
             name = [feature attributeForKey:@"name"];
-            languageCode = [feature attributeForKey:@"name_script"];
+            dominantScript = [feature attributeForKey:@"name_script"];
         }
 
         // If a feature hasn’t been translated into the preferred language, it
         // may be in the local language, which may be written in another script.
         // Attempt to transform to the script of the preferred language, keeping
         // the original string if no transform exists or if transformation fails.
-        NSString *dominantScript = [NSOrthography mgl_dominantScriptForMapboxStreetsLanguage:languageCode];
+        dominantScript = [NSOrthography mgl_dominantScriptForMapboxStreetsLanguage:languageCode];
         name = [name mgl_stringByTransliteratingIntoScript:dominantScript];
 
         self.accessibilityLabel = name;

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3092,7 +3092,7 @@ public:
                   name = [placeFeature attributeForKey:@"name"];
               }
 
-                if (![placesSet containsObject:name] && name != nil) {
+                if (![placesSet containsObject:name]) {
                     [placesArray addObject:name];
                     [placesSet addObject:name];
                 }

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3083,7 +3083,6 @@ public:
             NSMutableSet *placesSet = [NSMutableSet setWithCapacity:numberOfPlaces];
 
           for (id <MGLFeature> placeFeature in sortedPlaceFeatures){
-
               NSString *languageCode = [MGLVectorTileSource preferredMapboxStreetsLanguage];
               NSString *nameAttribute = [NSString stringWithFormat:@"name_%@", languageCode];
               NSString *name = [placeFeature attributeForKey:nameAttribute];

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3091,7 +3091,7 @@ public:
                   name = [placeFeature attributeForKey:@"name"];
               }
 
-                if (![placesSet containsObject:name]) {
+                if (![placesSet containsObject:name] && name != nil) {
                     [placesArray addObject:name];
                     [placesSet addObject:name];
                 }

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3083,8 +3083,16 @@ public:
             NSMutableSet *placesSet = [NSMutableSet setWithCapacity:numberOfPlaces];
 
           for (id <MGLFeature> placeFeature in sortedPlaceFeatures){
-                NSString *name = [placeFeature attributeForKey:@"name"];
-                if (![placesSet containsObject:name]) {
+
+              NSString *languageCode = [MGLVectorTileSource preferredMapboxStreetsLanguage];
+              NSString *nameAttribute = [NSString stringWithFormat:@"name_%@", languageCode];
+              NSString *name = [placeFeature attributeForKey:nameAttribute];
+
+              if (name == nil && [placeFeature attributeForKey:@"name"] != nil) {
+                  name = [placeFeature attributeForKey:@"name"];
+              }
+
+                if (![placesSet containsObject:name] && name != nil) {
                     [placesArray addObject:name];
                     [placesSet addObject:name];
                 }


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/13922

Previously, the source layer identifiers taken into account when generating accessibility elements were hardcoded. This PR:

* Adds an `NSSet` property to `MGLStyle` that allows users to specify additional sources that should be available for VoiceOver.

*  Use `name` attribute value as a fallback value when generating accessibility elements.

Caveats:
 
* This approach works for point features that belong to `MGLVectorStyleLayer`s.

Future work:

* We should allow users to specify which attribute values are available to accessibility.

cc @knov 
