### PR TITLE
Fix CI scripts for deploying releases

### DIFF
--- a/platform/ios/scripts/deploy-packages.sh
+++ b/platform/ios/scripts/deploy-packages.sh
@@ -112,12 +112,8 @@ if [[ "${GITHUB_RELEASE}" == true ]]; then
         --description "${RELEASE_NOTES}"
 fi
 
-# TODO: Use bundle here. Consider using
-#    carthage build --no-skip-current
-#    carthage archive Mapbox MapboxMobileEvents
-# ?
-#
-#buildPackageStyle "iframework" "dynamic-with-events"
+# Build bundle
+buildPackageStyle "iframework" "dynamic-with-events"
 
 # Used for Cocoapods/Carthage
 buildPackageStyle "iframework" "dynamic"

--- a/platform/ios/scripts/package.sh
+++ b/platform/ios/scripts/package.sh
@@ -164,10 +164,11 @@ if [[ ${BUILD_FOR_DEVICE} == true ]]; then
         copyAndMakeFatFramework "${NAME}"
 
         if [[ ${INCLUDE_EVENTS_IN_PACKAGE} == true ]]; then
-            copyAndMakeFatFramework "MapboxMobileEvents"
+            step "Copying in MapboxMobileEvents.framework from Carthage directory"
+            cp -rv Carthage/Build/iOS/MapboxMobileEvents.framework ${OUTPUT}/dynamic
+            cp -rv Carthage/Build/iOS/MapboxMobileEvents.framework.dSYM ${OUTPUT}/dynamic
+            cp -rv Carthage/Build/iOS/*.bcsymbolmap ${OUTPUT}/dynamic
         fi
-
-        # Bundling mapbox-events-ios
     fi
     
     cp -rv platform/ios/app/Settings.bundle ${OUTPUT}

--- a/platform/ios/scripts/publish.sh
+++ b/platform/ios/scripts/publish.sh
@@ -50,10 +50,17 @@ fi
 
 step "Uploading ${ZIP_FILENAME} to s3… ${DRYRUN}"
 
-aws s3 cp ${ZIP_FILENAME} s3://mapbox-api-downloads-production/v2/mobile-maps/releases/ios/${PUBLISH_VERSION}/packages/${ZIP_FILENAME} ${PROGRESS} ${DRYRUN}
+if [ ${PUBLISH_STYLE} = "dynamic-with-events" ]; then
+    S3_DESTINATION=s3://mapbox-api-downloads-production/v2/mobile-maps/releases/ios/${PUBLISH_VERSION}/${ZIP_FILENAME}
+    DOWNLOAD_URL=https://api.mapbox.com/downloads/v2/mobile-maps/releases/ios/${PUBLISH_VERSION}/${ZIP_FILENAME}
+else
+    S3_DESTINATION=s3://mapbox-api-downloads-production/v2/mobile-maps/releases/ios/${PUBLISH_VERSION}/packages/${ZIP_FILENAME}
+    DOWNLOAD_URL=https://api.mapbox.com/downloads/v2/mobile-maps/releases/ios/packages/${PUBLISH_VERSION}/${ZIP_FILENAME}
+fi 
 
-S3_URL=https://api.mapbox.com/downloads/v2/mobile-maps/releases/ios/packages/${PUBLISH_VERSION}/${ZIP_FILENAME}
-step "Download URL will be ${S3_URL}"
+step "About to upload binaries to ${S3_DESTINATION}"
+aws s3 cp ${ZIP_FILENAME} ${S3_DESTINATION} ${PROGRESS} ${DRYRUN}
+step "Download URL will be ${DOWNLOAD_URL}"
 
 # TODO:
 


### PR DESCRIPTION
This PR fixes the release scripts after the move to consuming gl-native as a binary dependency.
