### PR TITLE
[ios] Add Xcode 11.6.0, 12.0 to nightly jobs.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,8 +19,7 @@ workflows:
       - ios-build:
           matrix:
             parameters:
-              #xcode: ["11.3.1", "11.5.0"]
-              xcode: ["11.3.1", "11.4.1", "11.5.0", "11.6.0", "12.0.0"]
+              xcode: ["11.3.1", "11.5.0"]
               buildtype: ["Debug", "Release"]
       - ios-release-template:
           requires: 

--- a/circle.yml
+++ b/circle.yml
@@ -16,23 +16,31 @@ workflows:
       #     unique aspect of the build environment.
       #   - {build type} is typically "debug" or "release".
       #
-      - ios-debug
-      - ios-debug-xcode10
-      - ios-debug-xcode11-5
+      - ios-build:
+          matrix:
+            parameters:
+              xcode: ["11.3.1", "11.5.0"]
+              buildtype: ["Debug", "Release"]
       - ios-release-template:
+          requires: 
+            - ios-build
           name: ios-release
+      # This should depend on sanitize jobs              
+      - ios-release-tag:
+          requires: 
+            - ios-release
+          filters:
+            tags:
+              only: /ios-.*/
+            branches:
+              ignore: /.*/
       - ios-trigger-metrics:
           requires: 
             - ios-release
           filters:
             branches:
               only: master
-      - ios-release-tag:
-          filters:
-            tags:
-              only: /ios-.*/
-            branches:
-              ignore: /.*/
+
       # - macos-debug
   nightly:
     triggers:
@@ -43,13 +51,28 @@ workflows:
               only:
                 - master
     jobs:
-      - metrics-nightly
+      - ios-build:
+          matrix:
+            parameters:
+              xcode: ["11.3.1", "11.4.1", "11.5.0", "11.6.0", "12.0.0"]
+              buildtype: ["Debug", "Release"]
+      - ios-sanitize-nightly:
+          requires:
+            - ios-build
+      # TODO: Add matrix for these                  
+      - ios-sanitize-address-nightly:
+          requires:
+            - ios-build
+      - ios-static-analyzer-nightly:
+          requires:
+            - ios-build
       - ios-release-template:
+          requires:
+            - ios-build
           name: ios-release-nightly
-      - ios-sanitize-nightly
-      - ios-sanitize-address-nightly
-      - ios-static-analyzer-nightly
-      - ios-static-analyzer-nightly-xcode10
+      - metrics-nightly:      
+          requires:
+            - ios-release-nightly
 
 commands:
   npm-install:
@@ -275,11 +298,18 @@ commands:
           fi
 
 jobs:
-  ios-debug:
+
+  ios-build:
+    parameters:
+      xcode:
+        type: string
+      buildtype:
+        type: string
+        default: Debug
     macos:
-      xcode: "11.4.1"
+      xcode: << parameters.xcode >>
     environment:
-      BUILDTYPE: Debug
+      BUILDTYPE: << parameters.buildtype >>
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_NO_INSTALL_CLEANUP: 1
     steps:
@@ -295,47 +325,7 @@ jobs:
       - collect-xcode-build-logs
       - upload-xcode-build-logs
 
-# ------------------------------------------------------------------------------
-# TODO: Update to latest on macOS 10.14 Mojave, i.e. 11.3.1
-  ios-debug-xcode10:
-    macos:
-      xcode: "10.3.0"
-    environment:
-      BUILDTYPE: Debug
-      HOMEBREW_NO_AUTO_UPDATE: 1
-      HOMEBREW_NO_INSTALL_CLEANUP: 1
-    steps:
-      - install-macos-dependencies
-      - install-dependencies
-      - check-public-symbols
-      - run:
-          name: Lint podspecs and plist files
-          command: make ios-lint
-      - check-if-this-job-can-be-skipped
-      - build-ios-test
-      - save-dependencies
-      - collect-xcode-build-logs
-      - upload-xcode-build-logs
 
-  ios-debug-xcode11-5:
-    macos:
-      xcode: "11.5.0"
-    environment:
-      BUILDTYPE: Debug
-      HOMEBREW_NO_AUTO_UPDATE: 1
-      HOMEBREW_NO_INSTALL_CLEANUP: 1
-    steps:
-      - install-macos-dependencies
-      - install-dependencies
-      - check-public-symbols
-      - run:
-          name: Lint podspecs and plist files
-          command: make ios-lint
-      - check-if-this-job-can-be-skipped
-      - build-ios-test
-      - save-dependencies
-      - collect-xcode-build-logs
-      - upload-xcode-build-logs
 
 
 # ------------------------------------------------------------------------------
@@ -402,24 +392,24 @@ jobs:
       - upload-xcode-build-logs
       - notify-slack-nightly-failure
 
-# ------------------------------------------------------------------------------
-  ios-static-analyzer-nightly-xcode10:
-    macos:
-      xcode: "10.3.0"
-    environment:
-      BUILDTYPE: Debug
-      HOMEBREW_NO_AUTO_UPDATE: 1
-      HOMEBREW_NO_INSTALL_CLEANUP: 1
-    steps:
-      - install-macos-dependencies
-      - install-dependencies
-      - run:
-          name: Build and run SDK unit tests with the static analyzer
-          command: make ios-static-analyzer
-      - save-dependencies
-      - collect-xcode-build-logs
-      - upload-xcode-build-logs
-      - notify-slack-nightly-failure
+# # ------------------------------------------------------------------------------
+#   ios-static-analyzer-nightly-xcode10:
+#     macos:
+#       xcode: "10.3.0"
+#     environment:
+#       BUILDTYPE: Debug
+#       HOMEBREW_NO_AUTO_UPDATE: 1
+#       HOMEBREW_NO_INSTALL_CLEANUP: 1
+#     steps:
+#       - install-macos-dependencies
+#       - install-dependencies
+#       - run:
+#           name: Build and run SDK unit tests with the static analyzer
+#           command: make ios-static-analyzer
+#       - save-dependencies
+#       - collect-xcode-build-logs
+#       - upload-xcode-build-logs
+#       - notify-slack-nightly-failure
 
 # ------------------------------------------------------------------------------
   ios-release-template:

--- a/circle.yml
+++ b/circle.yml
@@ -22,12 +22,11 @@ workflows:
               xcode: ["11.3.1", "11.5.0"]
               buildtype: ["Debug", "Release"]
       - ios-release-template:
-          requires: 
-            - ios-build
           name: ios-release
       # This should depend on sanitize jobs              
       - ios-release-tag:
           requires: 
+            - ios-build
             - ios-release
           filters:
             tags:
@@ -36,6 +35,7 @@ workflows:
               ignore: /.*/
       - ios-trigger-metrics:
           requires: 
+            - ios-build
             - ios-release
           filters:
             branches:

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,8 @@ workflows:
       - ios-build:
           matrix:
             parameters:
-              xcode: ["11.3.1", "11.5.0"]
+              #xcode: ["11.3.1", "11.5.0"]
+              xcode: ["11.3.1", "11.4.1", "11.5.0", "11.6.0", "12.0.0"]
               buildtype: ["Debug", "Release"]
       - ios-release-template:
           requires: 

--- a/platform/darwin/test/MGLOfflinePackTests.mm
+++ b/platform/darwin/test/MGLOfflinePackTests.mm
@@ -23,8 +23,12 @@
 - (void)testInvalidatingAnInvalidPack {
     MGLOfflinePack *invalidPack = [[MGLOfflinePack alloc] init];
 
+#if defined(NS_BLOCK_ASSERTIONS)
+    NSLog(@"NSAssertions are blocked (Release build?), skipping invalidate XCTAssert.");
+#else
     XCTAssertThrowsSpecificNamed([invalidPack invalidate], NSException, NSInternalInconsistencyException, @"Invalid offline pack should raise an exception when being invalidated.");
-
+#endif
+    
     // Now try again, without asserts
     NSAssertionHandler *oldHandler = [NSAssertionHandler currentHandler];
     MGLTestAssertionHandler *newHandler = [[MGLTestAssertionHandler alloc] initWithTestCase:self];

--- a/platform/ios/test/MGLMapViewLayoutTests.m
+++ b/platform/ios/test/MGLMapViewLayoutTests.m
@@ -237,12 +237,16 @@
 
         //invoke layout
         [self.superView setNeedsLayout];
+#if defined(NS_BLOCK_ASSERTIONS)
+        NSLog(@"NSAssertions are blocked (Release build?), skipping layoutIfNeeded XCTAssert.");
+#else
         XCTAssertThrowsSpecificNamed(
                                      [self.superView layoutIfNeeded],
                                      NSException,
                                      NSInternalInconsistencyException,
                                      @"should throw NSInternalInconsistencyException"
                                      );
+#endif
     }
 }
 
@@ -350,12 +354,17 @@
 
         //invoke layout
         [self.superView setNeedsLayout];
+#if defined(NS_BLOCK_ASSERTIONS)
+        NSLog(@"NSAssertions are blocked (Release build?), skipping layoutIfNeeded XCTAssert.");
+#else
+        
         XCTAssertThrowsSpecificNamed(
                                      [self.superView layoutIfNeeded],
                                      NSException,
                                      NSInternalInconsistencyException,
                                      @"should throw NSInternalInconsistencyException"
                                      );
+#endif
     }
 }
 
@@ -392,12 +401,17 @@
 
         //invoke layout
         [self.superView setNeedsLayout];
+#if defined(NS_BLOCK_ASSERTIONS)
+        NSLog(@"NSAssertions are blocked (Release build?), skipping layoutIfNeeded XCTAssert.");
+#else
+        
         XCTAssertThrowsSpecificNamed(
                                      [self.superView layoutIfNeeded],
                                      NSException,
                                      NSInternalInconsistencyException,
                                      @"should throw NSInternalInconsistencyException"
                                      );
+#endif
     }
 }
 

--- a/platform/ios/test/MGLNetworkConfigurationTests.m
+++ b/platform/ios/test/MGLNetworkConfigurationTests.m
@@ -21,7 +21,7 @@
     
     for (NSUInteger i = 0; i < numberOfConcurrentBlocks; i++) {
         
-        NSString *event = [NSString stringWithFormat:@"test://event-%ld", i];
+        NSString *event = [NSString stringWithFormat:@"test://event-%lu", (unsigned long)i];
         NSString *resourceType = @"test";
         
         dispatch_async(queue, ^{


### PR DESCRIPTION
This PR updates Xcode versions for build/testing:

For regular commits, CircleCI now uses Xcode `11.3.1` and `11.5.0`. (These being the two latest stable Xcode versions on Catalina and Mojave.)

For nightly builds, it uses Xcode `11.3.1`, `11.4.1`, `11.5.0`, `11.6.0`, `12.0.0`. i.e. including recent betas.

It now also builds for Release (as well as Debug) - though some tests have been modified since asserts are compiled out in Release configuration.

This PR does not update any of the sanitize jobs, nor does it change the version of Xcode that releases are built with.
