### PR TITLE
iOS 14 location privacy settings update

### DIFF
--- a/platform/darwin/src/MGLLocationManager.h
+++ b/platform/darwin/src/MGLLocationManager.h
@@ -88,6 +88,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)setActivityType:(CLActivityType)activityType;
 
+/**
+ Requests the user's permission to temporarily use location update services
+ with full accuracy.
+ 
+ @note If the user turned off location accuracy you may use this method to
+ request full accuracy for a session.
+ */
+- (void)requestTemporaryFullAccuracyAuthorizationWithPurposeKey:(NSString *)purposeKey API_AVAILABLE(ios(14));
+
 @required
 
 /**

--- a/platform/darwin/src/MGLLocationManager.h
+++ b/platform/darwin/src/MGLLocationManager.h
@@ -58,15 +58,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)setDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy;
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
 /**
  Specifies the level of location accuracy the Maps SDK has permission to use.
  
  @note If the value of this property is `CLAccuracyAuthorizationFullAccuracy`, you can set the
- `desiredAccuracy` property to any value. If the value is `CLAccuracyAuthorizationReducedAccuracy`,
- setting `desiredAccuracy` to a value other than` kCLLocationAccuracyReduced` has no effect on
+ `MGLLocationManager.desiredAccuracy` property to any value. If the value is `CLAccuracyAuthorizationReducedAccuracy`,
+ setting `MGLLocationManager.desiredAccuracy` to a value other than` kCLLocationAccuracyReduced` has no effect on
  the location information.
  */
 - (CLAccuracyAuthorization)accuracyAuthorization API_AVAILABLE(ios(14));
+#endif
 
 /**
  Specifies the type of user activity associated with the location updates.
@@ -88,6 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)setActivityType:(CLActivityType)activityType;
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
 /**
  Requests the user's permission to temporarily use location update services
  with full accuracy.
@@ -96,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
  request full accuracy for a session.
  */
 - (void)requestTemporaryFullAccuracyAuthorizationWithPurposeKey:(NSString *)purposeKey API_AVAILABLE(ios(14));
-
+#endif
 @required
 
 /**

--- a/platform/darwin/src/MGLLocationManager.h
+++ b/platform/darwin/src/MGLLocationManager.h
@@ -59,6 +59,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy;
 
 /**
+ Specifies the level of location accuracy the Maps SDK has permission to use.
+ 
+ @note If the value of this property is `CLAccuracyAuthorizationFullAccuracy`, you can set the
+ `desiredAccuracy` property to any value. If the value is `CLAccuracyAuthorizationReducedAccuracy`,
+ setting `desiredAccuracy` to a value other than` kCLLocationAccuracyReduced` has no effect on
+ the location information.
+ */
+- (CLAccuracyAuthorization)accuracyAuthorization API_AVAILABLE(ios(14));
+
+/**
  Specifies the type of user activity associated with the location updates.
  
  The location manager uses this property as a cue to determine when location updates

--- a/platform/darwin/src/MGLLocationManager.m
+++ b/platform/darwin/src/MGLLocationManager.m
@@ -38,7 +38,11 @@
 }
 
 - (CLAuthorizationStatus)authorizationStatus {
-    return [CLLocationManager authorizationStatus];
+    if (@available(iOS 14.0, *)) {
+        return self.locationManager.authorizationStatus;
+    } else {
+        return [CLLocationManager authorizationStatus];
+    }
 }
 
 - (void)setActivityType:(CLActivityType)activityType {
@@ -47,6 +51,14 @@
 
 - (CLActivityType)activityType {
     return self.locationManager.activityType;
+}
+
+- (CLAccuracyAuthorization)accuracyAuthorization {
+    if (@available(iOS 14.0, *)) {
+        return self.locationManager.accuracyAuthorization;
+    } else {
+        return CLAccuracyAuthorizationFullAccuracy;
+    }
 }
 
 - (void)dismissHeadingCalibrationDisplay {

--- a/platform/darwin/src/MGLLocationManager.m
+++ b/platform/darwin/src/MGLLocationManager.m
@@ -61,6 +61,12 @@
     }
 }
 
+- (void)requestTemporaryFullAccuracyAuthorizationWithPurposeKey:(NSString *)purposeKey {
+    if (@available(iOS 14.0, *)) {
+        [self.locationManager requestTemporaryFullAccuracyAuthorizationWithPurposeKey:purposeKey];
+    } 
+}
+
 - (void)dismissHeadingCalibrationDisplay {
     [self.locationManager dismissHeadingCalibrationDisplay];
 }

--- a/platform/darwin/src/MGLLocationManager.m
+++ b/platform/darwin/src/MGLLocationManager.m
@@ -38,11 +38,15 @@
 }
 
 - (CLAuthorizationStatus)authorizationStatus {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
     if (@available(iOS 14.0, *)) {
         return self.locationManager.authorizationStatus;
     } else {
-        return [CLLocationManager authorizationStatus];
+        return kCLAuthorizationStatusNotDetermined;
     }
+#else
+    return [CLLocationManager authorizationStatus];
+#endif
 }
 
 - (void)setActivityType:(CLActivityType)activityType {
@@ -53,6 +57,7 @@
     return self.locationManager.activityType;
 }
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
 - (CLAccuracyAuthorization)accuracyAuthorization {
     if (@available(iOS 14.0, *)) {
         return self.locationManager.accuracyAuthorization;
@@ -66,6 +71,7 @@
         [self.locationManager requestTemporaryFullAccuracyAuthorizationWithPurposeKey:purposeKey];
     } 
 }
+#endif
 
 - (void)dismissHeadingCalibrationDisplay {
     [self.locationManager dismissHeadingCalibrationDisplay];

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+# master
+
+### ✨ New features
+
+* Added `MGLLocationManager.accuracyAuthorization` and `[MGLLocationManager requestTemporaryFullAccuracyAuthorizationWithPurposeKeyproperty:]` to support iOS 14 location accuracy privacy changes. ([#361](https://github.com/mapbox/mapbox-gl-native-ios/pull/361))
+
 ## 6.1.0
 
 * Added the `MGLStyle.accessiblePlaceSourceLayerIdentifiers` property to cause VoiceOver to read aloud certain layers in `MGLVectorTileSource`s as places, the same way that certain layers in the Mapbox Streets source are already read aloud as places. ([#336](https://github.com/mapbox/mapbox-gl-native-ios/pull/336))


### PR DESCRIPTION
Fixes #337 

iOS 14 has a new privacy setting related to location accuracy. It means that users may be able to revoke the level of location accuracy the app has permission to use. When this happens apps will not be able to change manually this setting. However in order to request full location accuracy for a short period of time this pr introduces `requestTemporaryFullAccuracyAuthorizationWithPurposeKey` which is on pair of `CLLocationManager. requestTemporaryFullAccuracyAuthorizationWithPurposeKey`. Developers can check the location accuracy `MGLLocationManager. accuracyAuthorization` and if it is `CLAccuracyAuthorizationReducedAccuracy` then they can call `requestTemporaryFullAccuracyAuthorizationWithPurposeKey` to gain full accuracy for a short period of time. Enough to complete their use case.