### PR TITLE
Add Logging level tests (and vararg version of logCallingFunction)

### DIFF
--- a/platform/darwin/src/MGLLoggingConfiguration.h
+++ b/platform/darwin/src/MGLLoggingConfiguration.h
@@ -82,7 +82,7 @@ MGL_EXPORT
  
  The default value is `MGLLoggingLevelNone`.
  
- Setting this property includes logging levels less than or equal to the setted value.
+ Setting this property includes logging levels less than or equal to the set value.
  */
 @property (assign, nonatomic) MGLLoggingLevel loggingLevel;
 

--- a/platform/darwin/src/MGLLoggingConfiguration.mm
+++ b/platform/darwin/src/MGLLoggingConfiguration.mm
@@ -66,14 +66,16 @@ public:
     }
 }
 
+- (void)logCallingFunction:(const char *)callingFunction functionLine:(NSUInteger)functionLine messageType:(MGLLoggingLevel)type format:(id)messageFormat arguments:(va_list)args {
+    NSString *formattedMessage = [[NSString alloc] initWithFormat:messageFormat arguments:args];
+    _handler(type, @(callingFunction), functionLine, formattedMessage);
+}
+
 - (void)logCallingFunction:(const char *)callingFunction functionLine:(NSUInteger)functionLine messageType:(MGLLoggingLevel)type format:(id)messageFormat, ... {
     va_list formatList;
     va_start(formatList, messageFormat);
-    NSString *formattedMessage = [[NSString alloc] initWithFormat:messageFormat arguments:formatList];
+    [self logCallingFunction:callingFunction functionLine:functionLine messageType:type format:messageFormat arguments:formatList];
     va_end(formatList);
-    
-    _handler(type, @(callingFunction), functionLine, formattedMessage);
-    
 }
 
 - (MGLLoggingBlockHandler)defaultBlockHandler {

--- a/platform/darwin/src/MGLLoggingConfiguration_Private.h
+++ b/platform/darwin/src/MGLLoggingConfiguration_Private.h
@@ -18,10 +18,13 @@ NS_INLINE NSString *MGLStringFromNSEdgeInsets(NSEdgeInsets insets) {
 #define MGLLogError(...)
 #define MGLLogFault(...)
 
+#define MGLLogInfoV(message, args)
+#define MGLLogErrorV(message, args)
+
 #else
 
 #if MGL_LOGGING_ENABLE_DEBUG
-    #define MGLLogDebug(message, ...) MGLLogWithType(MGLLoggingLevelDebug, __PRETTY_FUNCTION__, __LINE__, message, ##__VA_ARGS__)
+    #define MGLLogDebug(message, ...)   MGLLogWithType(MGLLoggingLevelDebug, __PRETTY_FUNCTION__, __LINE__, message, ##__VA_ARGS__)
 #else
     #define MGLLogDebug(...)
 #endif
@@ -30,6 +33,9 @@ NS_INLINE NSString *MGLStringFromNSEdgeInsets(NSEdgeInsets insets) {
 #define MGLLogWarning(message, ...)  MGLLogWithType(MGLLoggingLevelWarning, __PRETTY_FUNCTION__, __LINE__, message, ##__VA_ARGS__)
 #define MGLLogError(message, ...)    MGLLogWithType(MGLLoggingLevelError, __PRETTY_FUNCTION__, __LINE__, message, ##__VA_ARGS__)
 #define MGLLogFault(message, ...)    MGLLogWithType(MGLLoggingLevelFault, __PRETTY_FUNCTION__, __LINE__, message, ##__VA_ARGS__)
+
+#define MGLLogInfoV(message, args)   MGLLogWithTypeV(MGLLoggingLevelInfo, __PRETTY_FUNCTION__, __LINE__, message, args)
+#define MGLLogErrorV(message, args)  MGLLogWithTypeV(MGLLoggingLevelError, __PRETTY_FUNCTION__, __LINE__, message, args)
 
 #endif
 
@@ -59,8 +65,17 @@ NS_INLINE NSString *MGLStringFromNSEdgeInsets(NSEdgeInsets insets) {
     } \
 }
 
+#define MGLLogWithTypeV(type, function, line, message, args) \
+{ \
+    if ([MGLLoggingConfiguration sharedConfiguration].loggingLevel != MGLLoggingLevelNone && type <= [MGLLoggingConfiguration sharedConfiguration].loggingLevel) \
+    { \
+        [[MGLLoggingConfiguration sharedConfiguration] logCallingFunction:function functionLine:line messageType:type format:(message) arguments:args]; \
+    } \
+}
+
 @interface MGLLoggingConfiguration (Private)
 
+- (void)logCallingFunction:(const char *)callingFunction functionLine:(NSUInteger)functionLine messageType:(MGLLoggingLevel)type format:(id)messageFormat arguments:(va_list)args;
 - (void)logCallingFunction:(const char *)callingFunction functionLine:(NSUInteger)functionLine messageType:(MGLLoggingLevel)type format:(id)messageFormat, ...;
 
 @end

--- a/platform/darwin/src/MGLLoggingConfiguration_Private.h
+++ b/platform/darwin/src/MGLLoggingConfiguration_Private.h
@@ -18,9 +18,6 @@ NS_INLINE NSString *MGLStringFromNSEdgeInsets(NSEdgeInsets insets) {
 #define MGLLogError(...)
 #define MGLLogFault(...)
 
-#define MGLLogInfoV(message, args)
-#define MGLLogErrorV(message, args)
-
 #else
 
 #if MGL_LOGGING_ENABLE_DEBUG
@@ -33,9 +30,6 @@ NS_INLINE NSString *MGLStringFromNSEdgeInsets(NSEdgeInsets insets) {
 #define MGLLogWarning(message, ...)  MGLLogWithType(MGLLoggingLevelWarning, __PRETTY_FUNCTION__, __LINE__, message, ##__VA_ARGS__)
 #define MGLLogError(message, ...)    MGLLogWithType(MGLLoggingLevelError, __PRETTY_FUNCTION__, __LINE__, message, ##__VA_ARGS__)
 #define MGLLogFault(message, ...)    MGLLogWithType(MGLLoggingLevelFault, __PRETTY_FUNCTION__, __LINE__, message, ##__VA_ARGS__)
-
-#define MGLLogInfoV(message, args)   MGLLogWithTypeV(MGLLoggingLevelInfo, __PRETTY_FUNCTION__, __LINE__, message, args)
-#define MGLLogErrorV(message, args)  MGLLogWithTypeV(MGLLoggingLevelError, __PRETTY_FUNCTION__, __LINE__, message, args)
 
 #endif
 
@@ -62,14 +56,6 @@ NS_INLINE NSString *MGLStringFromNSEdgeInsets(NSEdgeInsets insets) {
     if ([MGLLoggingConfiguration sharedConfiguration].loggingLevel != MGLLoggingLevelNone && type <= [MGLLoggingConfiguration sharedConfiguration].loggingLevel) \
     { \
         [[MGLLoggingConfiguration sharedConfiguration] logCallingFunction:function functionLine:line messageType:type format:(message), ##__VA_ARGS__]; \
-    } \
-}
-
-#define MGLLogWithTypeV(type, function, line, message, args) \
-{ \
-    if ([MGLLoggingConfiguration sharedConfiguration].loggingLevel != MGLLoggingLevelNone && type <= [MGLLoggingConfiguration sharedConfiguration].loggingLevel) \
-    { \
-        [[MGLLoggingConfiguration sharedConfiguration] logCallingFunction:function functionLine:line messageType:type format:(message) arguments:args]; \
     } \
 }
 

--- a/platform/darwin/src/MGLNetworkConfiguration.m
+++ b/platform/darwin/src/MGLNetworkConfiguration.m
@@ -127,13 +127,15 @@ NSString * const kMGLDownloadPerformanceEvent = @"mobile.performance_trace";
     [self sendEventForURLResponse:response withAction:@"cancel"];
 }
 
-- (void)debugLog:(NSString *)format, ... {
-    MGLLogDebug(format);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+// TODO: Remove in future release.
+- (void)debugLog:(nonnull NSString *)format, ... {
 }
 
-- (void)errorLog:(NSString *)format, ... {
-    MGLLogError(format);
+- (void)errorLog:(nonnull NSString *)format, ... {
 }
+#pragma clang diagnostic pop
 
 #pragma mark - Event management
 

--- a/platform/ios/app/MBXAppDelegate.m
+++ b/platform/ios/app/MBXAppDelegate.m
@@ -12,7 +12,7 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
 #ifndef MGL_DISABLE_LOGGING
-    [MGLLoggingConfiguration sharedConfiguration].loggingLevel = MGLLoggingLevelFault;
+    [MGLLoggingConfiguration sharedConfiguration].loggingLevel = MGLLoggingLevelDebug;
 #endif
 
     [MGLMetricsManager sharedManager].delegate = self;

--- a/platform/ios/app/MBXAppDelegate.m
+++ b/platform/ios/app/MBXAppDelegate.m
@@ -12,7 +12,7 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
 #ifndef MGL_DISABLE_LOGGING
-    [MGLLoggingConfiguration sharedConfiguration].loggingLevel = MGLLoggingLevelDebug;
+    [MGLLoggingConfiguration sharedConfiguration].loggingLevel = MGLLoggingLevelFault;
 #endif
 
     [MGLMetricsManager sharedManager].delegate = self;

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -404,6 +404,7 @@
 		CA65C4F821E9BB080068B0D4 /* MGLCluster.h in Headers */ = {isa = PBXBuildFile; fileRef = CA65C4F721E9BB080068B0D4 /* MGLCluster.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CA65C4F921E9BB080068B0D4 /* MGLCluster.h in Headers */ = {isa = PBXBuildFile; fileRef = CA65C4F721E9BB080068B0D4 /* MGLCluster.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CA6914B520E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CA6914B420E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.mm */; };
+		CA70A58224E44F03008B5361 /* MBXLoggingConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA70A58124E44F03008B5361 /* MBXLoggingConfigurationTests.m */; };
 		CA7766832229C10E0008DE9E /* MGLCompactCalloutView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA8848451CBAFB9800AB86E3 /* MGLCompactCalloutView.m */; };
 		CA7766842229C11A0008DE9E /* SMCalloutView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA88488A1CBB037E00AB86E3 /* SMCalloutView.m */; };
 		CA7965A824D212D60007E0C4 /* MGLEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = CA7965A624D212D60007E0C4 /* MGLEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1073,6 +1074,7 @@
 		CA60014A242BD8710041BBEC /* MGLIntegrationTestCase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLIntegrationTestCase.h; sourceTree = "<group>"; };
 		CA65C4F721E9BB080068B0D4 /* MGLCluster.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLCluster.h; sourceTree = "<group>"; };
 		CA6914B420E67F50002DB0EE /* MGLAnnotationViewIntegrationTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLAnnotationViewIntegrationTests.mm; path = "Annotation Tests/MGLAnnotationViewIntegrationTests.mm"; sourceTree = "<group>"; };
+		CA70A58124E44F03008B5361 /* MBXLoggingConfigurationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MBXLoggingConfigurationTests.m; sourceTree = "<group>"; };
 		CA7965A624D212D60007E0C4 /* MGLEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLEvent.h; sourceTree = "<group>"; };
 		CA7965A724D212D60007E0C4 /* MGLEvent.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLEvent.mm; sourceTree = "<group>"; };
 		CA7965AC24D2135F0007E0C4 /* MGLEvent_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLEvent_Private.h; sourceTree = "<group>"; };
@@ -1965,6 +1967,7 @@
 				409F43FB1E9E77D10048729D /* Swift Integration */,
 				4031ACFD1E9FD26900A3EA26 /* Test Helpers */,
 				CA86FF0D22D8D5A0009EB14A /* MGLNetworkConfigurationTests.m */,
+				CA70A58124E44F03008B5361 /* MBXLoggingConfigurationTests.m */,
 			);
 			name = "SDK Tests";
 			path = test;
@@ -3185,6 +3188,7 @@
 				1F8E8A81233A9FD9009B51ED /* MGLMapViewGestureRecognizerTests.mm in Sources */,
 				353D23961D0B0DFE002BE09D /* MGLAnnotationViewTests.m in Sources */,
 				DA0CD5901CF56F6A00A5F5A5 /* MGLFeatureTests.mm in Sources */,
+				CA70A58224E44F03008B5361 /* MBXLoggingConfigurationTests.m in Sources */,
 				556660D81E1D085500E2C41B /* MGLVersionNumber.m in Sources */,
 				4031ACFF1E9FD29F00A3EA26 /* MGLSDKTestHelpers.swift in Sources */,
 				16376B491FFEED010000563E /* MGLMapViewLayoutTests.m in Sources */,

--- a/platform/ios/test/MBXLoggingConfigurationTests.m
+++ b/platform/ios/test/MBXLoggingConfigurationTests.m
@@ -1,0 +1,155 @@
+#import <XCTest/XCTest.h>
+@import Mapbox;
+#import "MGLLoggingConfiguration_Private.h"
+
+@interface MBXLoggingConfigurationTests : XCTestCase
+@property (nonatomic, assign) MGLLoggingLevel loggingLevel;
+@end
+
+@implementation MBXLoggingConfigurationTests
+
+- (void)setUp {
+    self.loggingLevel = [MGLLoggingConfiguration sharedConfiguration].loggingLevel;
+
+    [super setUp];
+}
+
+- (void)tearDown {
+    [super tearDown];
+
+    [MGLLoggingConfiguration sharedConfiguration].handler = nil;
+    [MGLLoggingConfiguration sharedConfiguration].loggingLevel = self.loggingLevel;
+}
+
+- (void)internalTestLoggingLevel:(MGLLoggingLevel)level
+           expectingLogForLevels:(NSArray*)expectedLevels {
+
+    NSUInteger expectedCount = expectedLevels.count;
+
+    XCTestExpectation *expectation = [self expectationWithDescription:
+                                      [NSString stringWithFormat:@"Logging expecting %lu levels", expectedCount]];
+    if (expectedCount > 0) {
+        expectation.expectedFulfillmentCount = expectedCount;
+    }
+    else {
+        // If there are no expected levels, we don't expect any logs
+        expectation.inverted = YES;
+    }
+
+    [MGLLoggingConfiguration sharedConfiguration].loggingLevel = level;
+
+    [MGLLoggingConfiguration sharedConfiguration].handler = ^(MGLLoggingLevel loggingLevel, NSString * _Nonnull filePath, NSUInteger line, NSString * _Nonnull message) {
+        NSLog(@"(%lu) Level %ld: %@", (unsigned long)line, (long)loggingLevel, message);
+        XCTAssertEqualObjects(message, @(loggingLevel).stringValue);
+        XCTAssert([expectedLevels containsObject:@(loggingLevel)]);
+        [expectation fulfill];
+    };
+
+    MGLLogInfo(@"%d", MGLLoggingLevelInfo);
+    MGLLogWarning(@"%d", MGLLoggingLevelWarning);
+    MGLLogError(@"%d", MGLLoggingLevelError);
+    MGLLogFault(@"%d", MGLLoggingLevelFault);
+    MGLLogDebug(@"%d", MGLLoggingLevelDebug);
+
+    [self waitForExpectations:@[expectation] timeout:0.1];
+}
+
+- (void)testLoggingLevelNone {
+    [self internalTestLoggingLevel:MGLLoggingLevelNone expectingLogForLevels:@[]];
+}
+
+- (void)testLoggingLevelDebug {
+    [self internalTestLoggingLevel:MGLLoggingLevelDebug
+             expectingLogForLevels:@[
+        @(MGLLoggingLevelDebug),
+        @(MGLLoggingLevelInfo),
+        @(MGLLoggingLevelWarning),
+        @(MGLLoggingLevelError),
+        @(MGLLoggingLevelFault)
+    ]];
+}
+
+- (void)testLoggingLevelInfo {
+    [self internalTestLoggingLevel:MGLLoggingLevelInfo
+             expectingLogForLevels:@[
+//      @(MGLLoggingLevelDebug),
+        @(MGLLoggingLevelInfo),
+        @(MGLLoggingLevelWarning),
+        @(MGLLoggingLevelError),
+        @(MGLLoggingLevelFault)
+    ]];
+}
+
+- (void)testLoggingLevelWarning {
+    [self internalTestLoggingLevel:MGLLoggingLevelWarning
+             expectingLogForLevels:@[
+//      @(MGLLoggingLevelDebug),
+//      @(MGLLoggingLevelInfo),
+        @(MGLLoggingLevelWarning),
+        @(MGLLoggingLevelError),
+        @(MGLLoggingLevelFault)
+    ]];
+}
+
+- (void)testLoggingLevelError {
+    [self internalTestLoggingLevel:MGLLoggingLevelError
+             expectingLogForLevels:@[
+//      @(MGLLoggingLevelDebug),
+//      @(MGLLoggingLevelInfo),
+//      @(MGLLoggingLevelWarning),
+        @(MGLLoggingLevelError),
+        @(MGLLoggingLevelFault)
+    ]];
+}
+
+- (void)testLoggingLevelFault {
+    [self internalTestLoggingLevel:MGLLoggingLevelFault
+             expectingLogForLevels:@[
+//      @(MGLLoggingLevelDebug),
+//      @(MGLLoggingLevelInfo),
+//      @(MGLLoggingLevelWarning),
+//      @(MGLLoggingLevelError),
+        @(MGLLoggingLevelFault)
+    ]];
+}
+
+- (void)testLoggingLevelVerbose {
+    [self internalTestLoggingLevel:MGLLoggingLevelVerbose
+             expectingLogForLevels:@[
+        @(MGLLoggingLevelDebug),
+        @(MGLLoggingLevelInfo),
+        @(MGLLoggingLevelWarning),
+        @(MGLLoggingLevelError),
+        @(MGLLoggingLevelFault)
+    ]];
+}
+
+- (void)internalTestLoggingExpectedResult:(NSString*)expected withFormat:(id)messageFormat, ... {
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"vaargs test"];
+    expectation.expectedFulfillmentCount = 2;
+    [MGLLoggingConfiguration sharedConfiguration].loggingLevel = MGLLoggingLevelVerbose;
+
+    [MGLLoggingConfiguration sharedConfiguration].handler = ^(MGLLoggingLevel loggingLevel, NSString * _Nonnull filePath, NSUInteger line, NSString * _Nonnull message) {
+        NSLog(@"(%lu) Level %ld: %@", (unsigned long)line, (long)loggingLevel, message);
+        XCTAssertEqualObjects(message, expected);
+        [expectation fulfill];
+    };
+
+    va_list formatList;
+
+    va_start(formatList, messageFormat);
+    MGLLogInfoV(messageFormat, formatList);
+    va_end(formatList);
+
+    va_start(formatList, messageFormat);
+    MGLLogErrorV(messageFormat, formatList);
+    va_end(formatList);
+    [self waitForExpectations:@[expectation] timeout:0.1];
+}
+
+- (void)testVarArgLogging {
+    [self internalTestLoggingExpectedResult:@"hello world 1" withFormat:@"hello %@ %d", @"world", 1];
+    [self internalTestLoggingExpectedResult:@"(\n    1,\n    2,\n    3\n)" withFormat:@"%@", @[@1, @2, @3]];
+}
+@end

--- a/platform/ios/test/MBXLoggingConfigurationTests.m
+++ b/platform/ios/test/MBXLoggingConfigurationTests.m
@@ -128,22 +128,32 @@
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"vaargs test"];
     expectation.expectedFulfillmentCount = 2;
-    [MGLLoggingConfiguration sharedConfiguration].loggingLevel = MGLLoggingLevelVerbose;
 
-    [MGLLoggingConfiguration sharedConfiguration].handler = ^(MGLLoggingLevel loggingLevel, NSString * _Nonnull filePath, NSUInteger line, NSString * _Nonnull message) {
+    MGLLoggingConfiguration *logger = [MGLLoggingConfiguration sharedConfiguration];
+
+    logger.loggingLevel = MGLLoggingLevelVerbose;
+
+    logger.handler = ^(MGLLoggingLevel loggingLevel, NSString * _Nonnull filePath, NSUInteger line, NSString * _Nonnull message) {
         NSLog(@"(%lu) Level %ld: %@", (unsigned long)line, (long)loggingLevel, message);
         XCTAssertEqualObjects(message, expected);
         [expectation fulfill];
     };
 
     va_list formatList;
-
     va_start(formatList, messageFormat);
-    MGLLogInfoV(messageFormat, formatList);
+    [logger logCallingFunction:__PRETTY_FUNCTION__
+                  functionLine:__LINE__
+                   messageType:MGLLoggingLevelInfo
+                        format:messageFormat
+                     arguments:formatList];
     va_end(formatList);
 
     va_start(formatList, messageFormat);
-    MGLLogErrorV(messageFormat, formatList);
+    [logger logCallingFunction:__PRETTY_FUNCTION__
+                  functionLine:__LINE__
+                   messageType:MGLLoggingLevelError
+                        format:messageFormat
+                     arguments:formatList];
     va_end(formatList);
     [self waitForExpectations:@[expectation] timeout:0.1];
 }


### PR DESCRIPTION
This PR adds unit tests as a part of: https://github.com/mapbox/mapbox-gl-native-ios/issues/370

See gl-native for the associated fix for #370 (which uses `Log::Observer` instead of calling down to `-[MGLNetworkConfiguration debugLog:]` etc).

Fixes #347 (along with next gl-native release)
Fixes https://github.com/mapbox/mapbox-gl-native/issues/16511