### PR TITLE
Fix typo in macOS map SDK installation instructions

### DIFF
--- a/platform/macos/docs/pod-README.md
+++ b/platform/macos/docs/pod-README.md
@@ -27,7 +27,7 @@ There are three ways to install the Mapbox Maps SDK for macOS:
 The Mapbox Maps SDK for macOS is a binary-only dependency, so you’ll need Carthage 0.19 or above. In your [Cartfile](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#binary-only-frameworks), specify this dependency (plus an optional version requirement):
 
 ```
-binary "https://mapbox.github.io/mapbox-gl-native-ios/macos/Mapbox-macOS-SDK.json"
+binary "https://mapbox.github.io/mapbox-gl-native/macos/Mapbox-macOS-SDK.json"
 ```
 
 After running `carthage update`, you’ll find Mapbox.framework in the Carthage/Build/ folder. Follow [these instructions](https://github.com/Carthage/Carthage#if-youre-building-for-os-x) to integrate it into your project.


### PR DESCRIPTION
The macOS map SDK documentation and Carthage binary project specification remained on the GitHub Pages site corresponding to the mapbox/mapbox-gl-native repository even after the codebase moved to mapbox/mapbox-gl-native-ios. An overzealous find-and-replace caused the installation instructions to be incorrect, preventing anyone from installing the SDK using Carthage.

Separately, I’ll go and manually patch the gh-pages branch to point to the right place.

/cc @mapbox/maps-ios @ZiZasaurus