### PR TITLE
Ask accuracy authorization when tracking mode is different from none

### DIFF
--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -2359,7 +2359,9 @@ CLLocationCoordinate2D randomWorldCoordinate() {
 - (void)mapView:(nonnull MGLMapView *)mapView didChangeLocationManagerAuthorization:(nonnull id<MGLLocationManager>)manager {
     if (@available(iOS 14, *)) {
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
-        if (manager.authorizationStatus == kCLAuthorizationStatusDenied || manager.accuracyAuthorization == CLAccuracyAuthorizationReducedAccuracy) {
+        if (mapView.userTrackingMode != MGLUserTrackingModeNone
+            && (manager.authorizationStatus == kCLAuthorizationStatusDenied
+            || manager.accuracyAuthorization == CLAccuracyAuthorizationReducedAccuracy)) {
             [self alertAccuracyChanges];
         }
 #endif

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -6105,7 +6105,8 @@ public:
     } else {
         if (@available(iOS 14, *)) {
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
-            if ((manager.authorizationStatus != kCLAuthorizationStatusRestricted ||
+            if (self.userTrackingMode != MGLUserTrackingModeNone &&
+                (manager.authorizationStatus != kCLAuthorizationStatusRestricted ||
                  manager.authorizationStatus != kCLAuthorizationStatusAuthorizedAlways ||
                  manager.authorizationStatus != kCLAuthorizationStatusAuthorizedWhenInUse) &&
                 manager.accuracyAuthorization == CLAccuracyAuthorizationReducedAccuracy &&


### PR DESCRIPTION
Changed request for accuracy permissions only when user tracking mode is different from `MGLUserTrackingModeNone`
