### PR TITLE
Fix map stuttering by switching render call to use setNeedsDisplay

### DIFF
--- a/platform/darwin/src/MGLSignpost.h
+++ b/platform/darwin/src/MGLSignpost.h
@@ -7,12 +7,20 @@
 #define SIGNPOST_CONCAT2(x,y)   x##y
 #define SIGNPOST_CONCAT(x,y)    SIGNPOST_CONCAT2(x,y)
 #define SIGNPOST_NAME(x)        SIGNPOST_CONCAT(signpost,x)
+
+// Use MGL_SIGNPOST_BEGIN & MGL_SIGNPOST_END around sections of code that you
+// wish to profile.
+// MGL_SIGNPOST_EVENT can be used for single one-off events
 //
-//#define MGL_EXPORT __attribute__((visibility ("default")))
+// For example:
 //
-//MGL_EXPORT extern os_log_t MGLDefaultSignpostLog;
-//MGL_EXPORT extern os_signpost_id_t MGLDefaultSignpost;
+//  os_signpost_id_t signpost = MGL_CREATE_SIGNPOST(log);
+//  MGL_SIGNPOST_BEGIN(log, signpost, "example");
+//  [self performAComputationallyExpensiveOperation];
+//  MGL_SIGNPOST_END(log, signpost, "example", "%d", numberOfWidgets);
 //
+//  MGL_SIGNPOST_EVENT(log, signpost, "error", "%d", errorCode);
+
 /**
  Create an os_log_t (for use with os_signposts) with the "com.mapbox.mapbox" subsystem.
  
@@ -25,14 +33,6 @@
  @param name Name for the log category.
  @return log object.
  */
-//MGL_EXPORT extern os_log_t MGLSignpostLogCreate(const char* name);
-
-
-
-//os_log_t log = os_log_create("com.mapbox.mapbox", name);
-//
-//OS_LOG_DISABLED
-
 
 #define MGL_CREATE_SIGNPOST(log) \
     ({ \
@@ -69,24 +69,5 @@
             } \
         } \
     })
-
-// Use MGL_SIGNPOST_BEGIN & MGL_SIGNPOST_END around sections of code that you
-// wish to profile.
-// MGL_SIGNPOST_EVENT can be used for single one-off events
-//
-// For example:
-//
-//  os_signpost_id_t signpost = MGL_CREATE_SIGNPOST();
-//  MGL_SIGNPOST_BEGIN(signpost, "example");
-//  [self performAComputationallyExpensiveOperation];
-//  MGL_SIGNPOST_END(signpost, "example", "%d", numberOfWidgets);
-//
-//  MGL_SIGNPOST_EVENT("error", "%d", errorCode);
-//
-//#define MGL_CREATE_SIGNPOST()                     MGL_NAMED_CREATE_SIGNPOST(MGLDefaultSignpostLog)
-//
-//#define MGL_SIGNPOST_BEGIN(signpost, name, ...)   MGL_NAMED_SIGNPOST_BEGIN(MGLDefaultSignpostLog, signpost, name, ##__VA_ARGS__)
-//#define MGL_SIGNPOST_END(signpost, name, ...)     MGL_NAMED_SIGNPOST_END(MGLDefaultSignpostLog, signpost, name, ##__VA_ARGS__)
-//#define MGL_SIGNPOST_EVENT(signpost, name, ...)   MGL_NAMED_SIGNPOST_EVENT(MGLDefaultSignpostLog, signpost, name, ##__VA_ARGS__)
 
 #endif /* MGLSignpost_h */

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -14,6 +14,10 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * The `MGLAccuracyAuthorizationDescription` as element of `NSLocationTemporaryUsageDescriptionDictionary` Info.plist key can now be set to describe why you request accuracy authorization. ([#392](https://github.com/mapbox/mapbox-gl-native-ios/pull/392))
 * Added `[MGLMapViewDelegate mapViewStyleForDefaultUserLocationAnnotationView:]` and `MGLUserLocationAnnotationViewStyle` class to allow developers customize the default user location annotation view UI style. ([#403](https://github.com/mapbox/mapbox-gl-native-ios/pull/403))
 
+### 🐞 Bug fixes
+
+* Fixed an issue where the map would hang periodically (on iOS 14 beta). ([#411](https://github.com/mapbox/mapbox-gl-native-ios/pull/411))
+
 ## 6.1.0 - August 26, 2020
 
 * Added the `MGLStyle.accessiblePlaceSourceLayerIdentifiers` property to cause VoiceOver to read aloud certain layers in `MGLVectorTileSource`s as places, the same way that certain layers in the Mapbox Streets source are already read aloud as places. ([#336](https://github.com/mapbox/mapbox-gl-native-ios/pull/336))

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -1931,6 +1931,10 @@ CLLocationCoordinate2D randomWorldCoordinate() {
     }
 }
 
++ (NSURL *)greenStyleURL {
+    return [[NSBundle bundleForClass:[self class]] URLForResource:@"green" withExtension:@"json"];
+}
+
 - (IBAction)cycleStyles:(__unused id)sender
 {
     static NSArray *styleNames;
@@ -1945,6 +1949,7 @@ CLLocationCoordinate2D randomWorldCoordinate() {
             @"Dark",
             @"Satellite",
             @"Satellite Streets",
+            @"Green"
         ];
         styleURLs = @[
             [MGLStyle streetsStyleURL],
@@ -1952,7 +1957,8 @@ CLLocationCoordinate2D randomWorldCoordinate() {
             [MGLStyle lightStyleURL],
             [MGLStyle darkStyleURL],
             [MGLStyle satelliteStyleURL],
-            [MGLStyle satelliteStreetsStyleURL]
+            [MGLStyle satelliteStreetsStyleURL],
+            [MBXViewController greenStyleURL]
         ];
         NSAssert(styleNames.count == styleURLs.count, @"Style names and URLs don’t match.");
 
@@ -1971,9 +1977,9 @@ CLLocationCoordinate2D randomWorldCoordinate() {
             }
         }
         free(methods);
-        NSAssert(numStyleURLMethods == styleNames.count,
+        NSAssert(numStyleURLMethods == styleNames.count - 1,
                  @"MGLStyle provides %u default styles but iosapp only knows about %lu of them.",
-                 numStyleURLMethods, (unsigned long)styleNames.count);
+                 numStyleURLMethods, (unsigned long)styleNames.count - 1);
     });
 
     self.styleIndex = (self.styleIndex + 1) % styleNames.count;

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -146,12 +146,12 @@ CLLocationCoordinate2D randomWorldCoordinate() {
         CLLocationDistance radius;
     } landmasses[] = {
         // Rough land masses
-//        {{ 38.328531,   94.778736 },    4100000 },  // Asia
-//        {{ 1.477244,    18.138111 },    4100000 },  // Africa
-//        {{ 52.310059,   22.295425 },    2000000 },  // Europe
-//        {{ 42.344216,   -96.532700 },   3000000 },  // N America
-//        {{ -11.537273,  -57.035181 },   2220000 },  // S America
-//        {{ -20.997030,  134.660541 },   2220000 },  // Australia
+        {{ 38.328531,   94.778736 },    4100000 },  // Asia
+        {{ 1.477244,    18.138111 },    4100000 },  // Africa
+        {{ 52.310059,   22.295425 },    2000000 },  // Europe
+        {{ 42.344216,   -96.532700 },   3000000 },  // N America
+        {{ -11.537273,  -57.035181 },   2220000 },  // S America
+        {{ -20.997030,  134.660541 },   2220000 },  // Australia
 
         // A few cities
         {{ 51.504787,   -0.106977 },    33000 },     // London
@@ -219,7 +219,6 @@ CLLocationCoordinate2D randomWorldCoordinate() {
 @property (nonatomic) BOOL frameTimeGraphEnabled;
 @property (nonatomic) BOOL shouldLimitCameraChanges;
 @property (nonatomic) BOOL randomWalk;
-@property (nonatomic) NSInteger randomWalkNumberOfLegs;
 @property (nonatomic) BOOL zoomLevelOrnamentEnabled;
 @property (nonatomic) NSMutableArray<UIWindow *> *helperWindows;
 @property (nonatomic) NSMutableArray<UIView *> *contentInsetsOverlays;
@@ -1779,10 +1778,6 @@ CLLocationCoordinate2D randomWorldCoordinate() {
     [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(31, -100) zoomLevel:3 animated:NO];
 
     [self randomWorldTourInternal];
-
-    self.randomWalkNumberOfLegs = 6;
-    self.mapView.experimental_enableSignpost = YES;
-    [self.mapView experimental_beginSignpostRegionNamed:@"randomwalk"];
 }
 
 - (void)randomWorldTourInternal {
@@ -1790,7 +1785,7 @@ CLLocationCoordinate2D randomWorldCoordinate() {
     self.randomWalk = YES;
 
     // Remove all annotations
-    NSTimeInterval duration = 8;//16.0;
+    NSTimeInterval duration = 16.0;
     __weak MBXViewController *weakSelf = self;
 
     // Remove old annotations, half-way through the flight.
@@ -1817,17 +1812,8 @@ CLLocationCoordinate2D randomWorldCoordinate() {
                 // for that, and set self.randomWalk. But since we want a delay
                 // anyway, we can just check later. Not ideal though..
                 dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-
                     MBXViewController *strongSelf = weakSelf;
-
-                    --strongSelf.randomWalkNumberOfLegs;
-
-                    if (strongSelf.randomWalkNumberOfLegs == 0) {
-                        [self.mapView experimental_endSignpostRegionNamed:@"randomwalk"];
-                        self.mapView.experimental_enableSignpost = NO;
-                        strongSelf.randomWalk = NO;
-                    }
-                    else if (strongSelf.randomWalk) {
+                    if (strongSelf.randomWalk) {
                         [strongSelf randomWorldTourInternal];
                     }
                 });

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -48,7 +48,8 @@ typedef NS_ENUM(NSInteger, MBXSettingsDebugToolsRows) {
     MBXSettingsDebugToolsOverdrawVisualization,
     MBXSettingsDebugToolsShowZoomLevel,
     MBXSettingsDebugToolsShowFrameTimeGraph,
-    MBXSettingsDebugToolsShowReuseQueueStats
+    MBXSettingsDebugToolsShowReuseQueueStats,
+    MBXSettingsDebugToolsSetPreferredFramesPerSecond
 };
 
 typedef NS_ENUM(NSInteger, MBXSettingsAnnotationsRows) {
@@ -391,7 +392,10 @@ CLLocationCoordinate2D randomWorldCoordinate() {
                     (debugMask & MGLMapDebugOverdrawVisualizationMask ? @"Hide" :@"Show")],
                 [NSString stringWithFormat:@"%@ zoom level ornament", (self.zoomLevelOrnamentEnabled ? @"Hide" :@"Show")],
                 [NSString stringWithFormat:@"%@ frame time graph", (self.frameTimeGraphEnabled ? @"Hide" :@"Show")],
-                [NSString stringWithFormat:@"%@ reuse queue stats", (self.reuseQueueStatsEnabled ? @"Hide" :@"Show")]
+                [NSString stringWithFormat:@"%@ reuse queue stats", (self.reuseQueueStatsEnabled ? @"Hide" :@"Show")],
+                ((self.mapView.preferredFramesPerSecond != MGLMapViewPreferredFramesPerSecondLowPower)?
+                 [NSString stringWithFormat:@"Set preferred FPS to: %ld", (long)MGLMapViewPreferredFramesPerSecondLowPower ] :
+                 @"Set preferred FPS to: Maximum")
             ]];
             break;
         case MBXSettingsAnnotations:
@@ -514,6 +518,16 @@ CLLocationCoordinate2D randomWorldCoordinate() {
                     self.hudLabel.hidden = !self.currentState.reuseQueueStatsEnabled;
                     self.zoomLevelOrnamentEnabled = NO;
                     [self updateHUD];
+                    break;
+                }
+                case MBXSettingsDebugToolsSetPreferredFramesPerSecond:
+                {
+                    if (self.mapView.preferredFramesPerSecond != MGLMapViewPreferredFramesPerSecondLowPower) {
+                        self.mapView.preferredFramesPerSecond = MGLMapViewPreferredFramesPerSecondLowPower;
+                    }
+                    else {
+                        self.mapView.preferredFramesPerSecond = MGLMapViewPreferredFramesPerSecondMaximum;
+                    }
                     break;
                 }
                 default:

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -49,7 +49,8 @@ typedef NS_ENUM(NSInteger, MBXSettingsDebugToolsRows) {
     MBXSettingsDebugToolsShowZoomLevel,
     MBXSettingsDebugToolsShowFrameTimeGraph,
     MBXSettingsDebugToolsShowReuseQueueStats,
-    MBXSettingsDebugToolsSetPreferredFramesPerSecond
+    MBXSettingsDebugToolsSetPreferredFramesPerSecond,
+    MBXSettingsDebugToolsSetSignpostEnabled
 };
 
 typedef NS_ENUM(NSInteger, MBXSettingsAnnotationsRows) {
@@ -395,7 +396,8 @@ CLLocationCoordinate2D randomWorldCoordinate() {
                 [NSString stringWithFormat:@"%@ reuse queue stats", (self.reuseQueueStatsEnabled ? @"Hide" :@"Show")],
                 ((self.mapView.preferredFramesPerSecond != MGLMapViewPreferredFramesPerSecondLowPower)?
                  [NSString stringWithFormat:@"Set preferred FPS to: %ld", (long)MGLMapViewPreferredFramesPerSecondLowPower ] :
-                 @"Set preferred FPS to: Maximum")
+                 @"Set preferred FPS to: Maximum"),
+                [NSString stringWithFormat:@"%@ signpost", (self.mapView.experimental_enableSignpost ? @"Disable" :@"Enable")]
             ]];
             break;
         case MBXSettingsAnnotations:
@@ -530,6 +532,12 @@ CLLocationCoordinate2D randomWorldCoordinate() {
                     }
                     break;
                 }
+                case MBXSettingsDebugToolsSetSignpostEnabled:
+                {
+                    self.mapView.experimental_enableSignpost = !self.mapView.experimental_enableSignpost;
+                    break;
+                }
+
                 default:
                     NSAssert(NO, @"All debug tools setting rows should be implemented");
                     break;

--- a/platform/ios/app/green.json
+++ b/platform/ios/app/green.json
@@ -1,0 +1,13 @@
+{
+  "version": 8,
+  "sources": {},
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {
+        "background-color": "green"
+      }
+    }
+  ]
+}

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -395,6 +395,7 @@
 		CA0FAA07237B3BC600C9F3C9 /* Mapbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA8847D21CBAF91600AB86E3 /* Mapbox.framework */; };
 		CA0FAA09237B3BEA00C9F3C9 /* Mapbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA8847D21CBAF91600AB86E3 /* Mapbox.framework */; };
 		CA17464E23D8A93C008B7A43 /* MGLNetworkConfigurationIntegrationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CA17464D23D8A93C008B7A43 /* MGLNetworkConfigurationIntegrationTests.mm */; };
+		CA1A739B24FEDBCE00703BBF /* green.json in Resources */ = {isa = PBXBuildFile; fileRef = CA1A739A24FEDBCE00703BBF /* green.json */; };
 		CA1B4A512099FB2200EDD491 /* MGLMapSnapshotterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CA1B4A502099FB2200EDD491 /* MGLMapSnapshotterTest.m */; };
 		CA3402782495E53900415EEE /* testQueryRoadsAroundDC.json in Resources */ = {isa = PBXBuildFile; fileRef = CA3402772495E53900415EEE /* testQueryRoadsAroundDC.json */; };
 		CA4C54FE2324948100A81659 /* MGLSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4C54FD2324948100A81659 /* MGLSourceTests.swift */; };
@@ -1067,6 +1068,7 @@
 		CA0C27932076CA19001CE5B7 /* MGLMapViewIntegrationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLMapViewIntegrationTest.m; sourceTree = "<group>"; wrapsLines = 0; };
 		CA0C27952076CA50001CE5B7 /* MGLMapViewIntegrationTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLMapViewIntegrationTest.h; sourceTree = "<group>"; };
 		CA17464D23D8A93C008B7A43 /* MGLNetworkConfigurationIntegrationTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLNetworkConfigurationIntegrationTests.mm; sourceTree = "<group>"; };
+		CA1A739A24FEDBCE00703BBF /* green.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = green.json; sourceTree = "<group>"; };
 		CA1B4A502099FB2200EDD491 /* MGLMapSnapshotterTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLMapSnapshotterTest.m; sourceTree = "<group>"; };
 		CA3402772495E53900415EEE /* testQueryRoadsAroundDC.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = testQueryRoadsAroundDC.json; sourceTree = "<group>"; };
 		CA4C54FD2324948100A81659 /* MGLSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MGLSourceTests.swift; sourceTree = "<group>"; };
@@ -1697,6 +1699,7 @@
 		9604FC341F313A5E003EEA02 /* Fixtures */ = {
 			isa = PBXGroup;
 			children = (
+				CA1A739A24FEDBCE00703BBF /* green.json */,
 				353BAEF51D646370009A8DA9 /* amsterdam.geojson */,
 				DA1DC96C1CB6C6CE006E619F /* points.geojson */,
 				A4F3FB1C2254865900A30170 /* missing_icon.json */,
@@ -2956,6 +2959,7 @@
 				DA821D071CCC6D59007508D4 /* Main.storyboard in Resources */,
 				DA1DC9731CB6C6CE006E619F /* threestates.geojson in Resources */,
 				DA821D061CCC6D59007508D4 /* LaunchScreen.storyboard in Resources */,
+				CA1A739B24FEDBCE00703BBF /* green.json in Resources */,
 				96E027231E57C76E004B8E66 /* Localizable.strings in Resources */,
 				1F26B6C320E1A351007BCC21 /* simple_route.json in Resources */,
 				DD4823751D94AE6C00EB71B7 /* fill_filter_style.json in Resources */,

--- a/platform/ios/src/MGLMapView+OpenGL.mm
+++ b/platform/ios/src/MGLMapView+OpenGL.mm
@@ -148,6 +148,7 @@ void MGLMapViewOpenGLImpl::deleteView() {
 }
 
 #ifdef MGL_RECREATE_GL_IN_AN_EMERGENCY
+// TODO: Fix or remove
 // See https://github.com/mapbox/mapbox-gl-native/issues/14232
 void MGLMapViewOpenGLImpl::emergencyRecreateGL() {
     auto& resource = getResource<MGLMapViewOpenGLRenderableResource>();

--- a/platform/ios/src/MGLMapView+OpenGL.mm
+++ b/platform/ios/src/MGLMapView+OpenGL.mm
@@ -100,34 +100,14 @@ void MGLMapViewOpenGLImpl::setPresentsWithTransaction(const bool value) {
 
 void MGLMapViewOpenGLImpl::display() {
     auto& resource = getResource<MGLMapViewOpenGLRenderableResource>();
-
-    // See https://github.com/mapbox/mapbox-gl-native/issues/14232
-    // glClear can be blocked for 1 second. This code is an "escape hatch",
-    // an attempt to detect this situation and rebuild the GL views.
-    if (mapView.enablePresentsWithTransaction && resource.atLeastiOS_12_2_0) {
-        CFTimeInterval before = CACurrentMediaTime();
-        [resource.glView display];
-        CFTimeInterval after = CACurrentMediaTime();
-
-        if (after - before >= 1.0) {
-#ifdef MGL_RECREATE_GL_IN_AN_EMERGENCY
-            dispatch_async(dispatch_get_main_queue(), ^{
-              emergencyRecreateGL();
-            });
-#else
-            static dispatch_once_t onceToken;
-            dispatch_once(&onceToken, ^{
-                NSError *error = [NSError errorWithDomain:MGLErrorDomain
-                                                     code:MGLErrorCodeRenderingError
-                                                 userInfo:@{ NSLocalizedFailureReasonErrorKey :
-                                                                 @"https://github.com/mapbox/mapbox-gl-native/issues/14232" }];
-                [[MMEEventsManager sharedManager] reportError:error];
-            });
-#endif
-        }
-    } else {
-        [resource.glView display];
-    }
+    // Calling `display` here directly causes the stuttering bug (if
+    // `presentsWithTransaction` is `YES` - see above)
+    // as reported in https://github.com/mapbox/mapbox-gl-native-ios/issues/350
+    //
+    // Since we use `presentsWithTransaction` to synchronize with UIView
+    // annotations, we now let the system handle when the view is rendered. This
+    // has the potential to increase latency
+    [resource.glView setNeedsDisplay];
 }
 
 void MGLMapViewOpenGLImpl::createView() {
@@ -150,7 +130,7 @@ void MGLMapViewOpenGLImpl::createView() {
     resource.glView.drawableDepthFormat = GLKViewDrawableDepthFormat16;
     resource.glView.opaque = mapView.opaque;
     resource.glView.layer.opaque = mapView.opaque;
-    resource.glView.enableSetNeedsDisplay = NO;
+    resource.glView.enableSetNeedsDisplay = YES;
     CAEAGLLayer* eaglLayer = MGL_OBJC_DYNAMIC_CAST(resource.glView.layer, CAEAGLLayer);
     eaglLayer.presentsWithTransaction = NO;
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -292,7 +292,8 @@ public:
 
 @property (nonatomic) NSMutableSet<MGLObserver *> *observerCache;
 
-@property (nonatomic) os_log_t log;
+@property (nonatomic, readwrite, nonnull) os_log_t log;
+@property (nonatomic, readwrite) os_signpost_id_t signpost;
 
 - (mbgl::Map &)mbglMap;
 
@@ -466,6 +467,7 @@ public:
     _opaque = NO;
 
     _log = os_log_create("com.mapbox.signposts", "MGLMapView");
+    _signpost = OS_SIGNPOST_ID_INVALID;
 
     // setup accessibility
 //  self.isAccessibilityElement = YES;
@@ -7038,6 +7040,25 @@ static std::vector<std::string> vectorOfStringsFromSet(NSSet<NSString *> *setOfS
     self.mbglMap.unsubscribe(observer.peer);
     [self.observerCache removeObject:observer];
     observer.observing = NO;
+}
+
+#pragma mark - Signposts -
+
+- (void)setExperimental_enableSignpost:(BOOL)enable
+{
+    if (enable) {
+        self.signpost = MGL_CREATE_SIGNPOST(self.log);
+        MGL_SIGNPOST_EVENT(self.log, self.signpost, "enableSignpost", "Signpost:YES");
+    }
+    else {
+        MGL_SIGNPOST_EVENT(self.log, self.signpost, "enableSignpost", "Signpost:NO");
+        self.signpost = OS_SIGNPOST_ID_INVALID;
+    }
+}
+
+- (BOOL)experimental_enableSignpost {
+    return ((self.signpost != OS_SIGNPOST_ID_INVALID) &&
+            (self.signpost != OS_SIGNPOST_ID_NULL));
 }
 
 @end

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1712,7 +1712,7 @@ public:
             NSError *error = [NSError errorWithDomain:MGLErrorDomain
                                                  code:MGLErrorCodeRenderingError
                                              userInfo:@{
-                                                 NSLocalizedDescriptionKey : [NSString stringWithFormat:@"%ld/%ld", self.numberOfRenderCallsMoreThanOneSecond, self.numberOfRenderCalls],
+                                                 NSLocalizedDescriptionKey : [NSString stringWithFormat:@"%ld/%ld", (long)self.numberOfRenderCallsMoreThanOneSecond, (long)self.numberOfRenderCalls],
                                                  NSLocalizedFailureReasonErrorKey : @"https://github.com/mapbox/mapbox-gl-native-ios/issues/350"
                                              }];
             [[MMEEventsManager sharedManager] reportError:error];

--- a/platform/ios/src/MGLMapView_Experimental.h
+++ b/platform/ios/src/MGLMapView_Experimental.h
@@ -32,4 +32,8 @@
  */
 @property (nonatomic, readonly) CFTimeInterval averageFrameTime;
 
+
+- (void)experimental_beginSignpostRegionNamed:(NSString*)region;
+- (void)experimental_endSignpostRegionNamed:(NSString*)region;
+
 @end

--- a/platform/ios/src/MGLMapView_Experimental.h
+++ b/platform/ios/src/MGLMapView_Experimental.h
@@ -7,6 +7,9 @@
 /** Enable rendering performance measurement. */
 @property (nonatomic) BOOL experimental_enableFrameRateMeasurement;
 
+/** Enable MGLMapView measurement via os_signpost. */
+@property (nonatomic) BOOL experimental_enableSignpost;
+
 /**
  Average frames per second over the previous second, updated once per second.
 

--- a/platform/ios/src/MGLMapView_Private.h
+++ b/platform/ios/src/MGLMapView_Private.h
@@ -1,8 +1,10 @@
 #import "MGLMapView.h"
 #import "MGLUserLocationAnnotationView.h"
 #import "MGLAnnotationContainerView.h"
+#import <os/signpost.h>
 
 #include <mbgl/util/size.hpp>
+
 
 namespace mbgl {
     class Map;
@@ -71,6 +73,9 @@ FOUNDATION_EXTERN MGL_EXPORT MGLExceptionName const _Nonnull MGLUnderlyingMapUna
 @property (nonatomic, nonnull) MGLUserLocationAnnotationView *userLocationAnnotationView;
 @property (nonatomic, nonnull) MGLAnnotationContainerView *annotationContainerView;
 @property (nonatomic, readonly) BOOL enablePresentsWithTransaction;
+
+@property (nonatomic, readonly, nonnull) os_log_t log;
+@property (nonatomic, readonly) os_signpost_id_t signpost;
 
 - (BOOL) _opaque;
 


### PR DESCRIPTION
This PR fixes #350, where the map "stutters" while being animated. The issue is reproducible in iOS 14 beta 2 onwards (as of 2020/9/3).

The PR supersedes changes made for similar bug first reported in https://github.com/mapbox/mapbox-gl-native/issues/14232 (`FB5350728`) and:

- switches from calling `-[GLKView display]` directly (via the `CADisplayLink` call), to calling `-[GLKView setNeedsDisplay]`,
- adds development `os_signpost`s for performance analysis,
- adds a few debug options to the development app `Mapbox GL`.

### Background

This issue is seen when enabling `CAEAGLLayer.presentsWithTransaction` and calling `-[GLKView display]` from a `CADisplayLink`. `presentsWithTransaction` is used to synchronize the `UIView` annotations to the map. The stutter that is seen is the CPU blocking with `wait for next drawable`. The issue can also be reproduced with a blank map (essentially just a `glClear`).

This effect can be mitigated by setting `preferredFramesPerSecond` to 30. 

This issue has been reported as `FB8549369`.