### PR TITLE
Switch background snapshot to periodic.

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -18,6 +18,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 ### 🐞 Bug fixes
 
 * Fixed an issue where the map would hang periodically (on iOS 14 beta). ([#411](https://github.com/mapbox/mapbox-gl-native-ios/pull/411))
+* Fixed a sporadic crash when resigning active. ([#412](https://github.com/mapbox/mapbox-gl-native-ios/pull/412))
 
 ## 6.1.0 - August 26, 2020
 


### PR DESCRIPTION
This PR fixes #44, by taking the background snapshot while the map is idle. 

Calling `snapshot` in response to `UIApplicationWillResignActiveNotification` appears to be no longer supported in OpenGL ([see the same issue](https://github.com/flutter/flutter/issues/50709#issuecomment-643544775) reported to the Flutter repo).

Another option is to completely remove snapshot handling, but without this we do see a momentary flash when coming into the foreground.

Since this PR periodically takes the snapshot, we now cross-fade from the snapshot view to the map view, to avoid a jarring transition.