### PR TITLE
Adds missing method for location integration test.

### DIFF
--- a/platform/ios/Integration Tests/MGLTestLocationManager.m
+++ b/platform/ios/Integration Tests/MGLTestLocationManager.m
@@ -41,4 +41,10 @@
 
 - (BOOL)locationManagerShouldDisplayHeadingCalibration:(CLLocationManager *)manager { return NO; }
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
+- (CLAccuracyAuthorization)accuracyAuthorization {
+    return CLAccuracyAuthorizationFullAccuracy;
+}
+#endif
+
 @end


### PR DESCRIPTION
The `testUserLocationWithOffsetAnchorPoint` integration test was failing due to a missing selector. This PR adds `MGLTestLocationManager.accuracyAuthorization`.