### PR TITLE
Changing the default size for approx ring border when zoomed out

### DIFF
--- a/platform/ios/src/MGLFaux3DUserLocationAnnotationView.mm
+++ b/platform/ios/src/MGLFaux3DUserLocationAnnotationView.mm
@@ -574,7 +574,7 @@ const CGFloat MGLUserLocationApproximateZoomThreshold = 7.0;
     if (_approximateLayer && (_oldZoom != self.mapView.zoomLevel || _oldHorizontalAccuracy != self.userLocation.location.horizontalAccuracy))
     {
         if (self.mapView.zoomLevel < MGLUserLocationApproximateZoomThreshold) {
-            borderSize = 3;
+            borderSize = 1.0;
         }
         _approximateLayer.borderWidth = borderSize;
         


### PR DESCRIPTION
This changes the logic to the standard zoomed out border width so that it is a reasonable size

<img src=https://user-images.githubusercontent.com/5885209/92942094-2b8c4d00-f41f-11ea-8f09-27f41f0fe780.png width=300>