### PR TITLE
Allow for transitive dependencies

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps-gl-core/mapbox-ios-sdk-gl-core-static.json" == 4.0.0
-github "mapbox/mapbox-events-ios" == 0.10.2
+github "mapbox/mapbox-events-ios" ~> 0.10.2

--- a/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
@@ -29,6 +29,6 @@ Pod::Spec.new do |m|
 
   m.preserve_path = '**/*.bcsymbolmap'
 
-  m.dependency "MapboxMobileEvents", "0.10.2"
+  m.dependency "MapboxMobileEvents", "~> 0.10.2"
 
 end

--- a/platform/ios/Mapbox-iOS-SDK-stripped.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-stripped.podspec
@@ -29,6 +29,6 @@ Pod::Spec.new do |m|
 
   m.preserve_path = '**/*.bcsymbolmap'
 
-  m.dependency "MapboxMobileEvents", "0.10.2"
+  m.dependency "MapboxMobileEvents", "~> 0.10.2"
 
 end

--- a/platform/ios/Mapbox-iOS-SDK.podspec
+++ b/platform/ios/Mapbox-iOS-SDK.podspec
@@ -29,5 +29,5 @@ Pod::Spec.new do |m|
 
   m.preserve_path = '**/*.bcsymbolmap'
 
-  m.dependency "MapboxMobileEvents", "0.10.2"
+  m.dependency "MapboxMobileEvents", "~> 0.10.2"
 end


### PR DESCRIPTION
Allow for transitive dependencies.

Currently when we are developing the next version of MME, the dependency tree cannot be resolved because MME in this SDK is pinned to a specific version.
```
[!] CocoaPods could not find compatible versions for pod "MapboxMobileEvents":
  In Podfile:
    Mapbox-iOS-SDK (~> 6.1.0) was resolved to 6.1.0, which depends on
      MapboxMobileEvents (= 0.10.2)
```

but I don't see any reason why we cannot allow for transitive dependencies so I'm adding the tadpole operator here.

cc @mapbox/maps-ios 