### PR TITLE
[macos] respect MGLMapSnapshotter on macOS.

### DIFF
--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -498,7 +498,7 @@ MGLImage *MGLAttributedSnapshot(mbgl::MapSnapshotter::Attributions attributions,
         return nil;
     }
     
-    if (logoImage) {
+    if (logoImage && options.showsLogo) {
         [logoImage drawInRect:logoImageRect];
     }
     

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for Mapbox Maps SDK for macOS
 
+## master
+
+* `MGLMapSnapshotOptions` to respect `showsLogo`. ([#335](https://github.com/mapbox/mapbox-gl-native-ios/issues/335))
+
 ## 0.16.0
 
 ### Styles and rendering


### PR DESCRIPTION
`<changelog>`MGLMapSnapshotOptions` to respect `showsLogo`. ([#335](https://github.com/mapbox/mapbox-gl-native-ios/issues/335))</changelog>`

#159 made it possible to set `showsLogo = false` on the snapshotter on iOS (when not using any mapbox services). As stated in #335, this did not work on macOS. This pull request fixes this on macOS as well.