### PR TITLE
Update gl-native to 5.1.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps-gl-core/mapbox-ios-sdk-gl-core-static.json" == 4.0.0
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps-gl-core/mapbox-ios-sdk-gl-core-static.json" == 5.1.0
 github "mapbox/mapbox-events-ios" ~> 0.10.4

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps-gl-core/mapbox-ios-sdk-gl-core-static.json" "4.0.0"
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps-gl-core/mapbox-ios-sdk-gl-core-static.json" "5.1.0"
 github "mapbox/mapbox-events-ios" "v0.10.4"

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -9,6 +9,11 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed an issue where completion blocks were not called until the map was rendered. ([#463](https://github.com/mapbox/mapbox-gl-native-ios/pull/463))
 * Fixed an issue that caused a crash when custom location managers did not implement `MGLLocationManager.accuracyAuthorization`. ([#474](https://github.com/mapbox/mapbox-gl-native-ios/pull/474))
 * Fixed a crash that occurred when `MGLIdeographicFontFamilyName` was set to `NO`. ([#467](https://github.com/mapbox/mapbox-gl-native-ios/pull/467), [#476](https://github.com/mapbox/mapbox-gl-native-ios/pull/476))
+* Fixed an issue with local font glyph rendering, by updating the core library to version 5.1.0. ([#475](https://github.com/mapbox/mapbox-gl-native-ios/pull/475))
+
+### 🔧 Dependencies
+
+* Core library updated to `5.1.0`. ([#475](https://github.com/mapbox/mapbox-gl-native-ios/pull/475))
 
 ## 6.2.0 - September 17, 2020
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -13,7 +13,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ### 🔧 Dependencies
 
-* Core library updated to `5.1.0`. ([#475](https://github.com/mapbox/mapbox-gl-native-ios/pull/475))
+* Core library updated to `5.1.0`. ([#475](https://github.com/mapbox/mapbox-gl-native-ios/pull/475)) 
 
 ## 6.2.0 - September 17, 2020
 


### PR DESCRIPTION
Fixes #450 
Fixes #471 

This PR updates the core library to fix the default behavior that was broken when previously upgrading to 5.0.0.

There are two related issues, that are required, to fix crashes:
- https://github.com/mapbox/mapbox-gl-native-ios/pull/467
- https://github.com/mapbox/mapbox-gl-native-ios/issues/472
