### PR TITLE
Made changes to podspec for Xcode 12 build issues 

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -16,7 +16,6 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed a crash that occurred when `MGLIdeographicFontFamilyName` was set to `NO`. ([#467](https://github.com/mapbox/mapbox-gl-native-ios/pull/467), [#476](https://github.com/mapbox/mapbox-gl-native-ios/pull/476))
 * Fixed an issue with local font glyph rendering, by updating the core library to version 5.1.0. ([#475](https://github.com/mapbox/mapbox-gl-native-ios/pull/475))
 
-
 ### 🔧 Dependencies
 
 * Core library updated to `5.1.0`. ([#475](https://github.com/mapbox/mapbox-gl-native-ios/pull/475)) 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+* Fixed an Xcode 12 issue that requires arm64 simulator architectures to be excluded. ([#482](https://github.com/mapbox/mapbox-gl-native-ios/pull/82))
+
 ## 6.2.1 - September 23, 2020
 
 ### 🐞 Bug fixes
@@ -10,6 +12,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed an issue that caused a crash when custom location managers did not implement `MGLLocationManager.accuracyAuthorization`. ([#474](https://github.com/mapbox/mapbox-gl-native-ios/pull/474))
 * Fixed a crash that occurred when `MGLIdeographicFontFamilyName` was set to `NO`. ([#467](https://github.com/mapbox/mapbox-gl-native-ios/pull/467), [#476](https://github.com/mapbox/mapbox-gl-native-ios/pull/476))
 * Fixed an issue with local font glyph rendering, by updating the core library to version 5.1.0. ([#475](https://github.com/mapbox/mapbox-gl-native-ios/pull/475))
+
 
 ### 🔧 Dependencies
 

--- a/platform/ios/Mapbox-iOS-SDK.podspec
+++ b/platform/ios/Mapbox-iOS-SDK.podspec
@@ -30,4 +30,9 @@ Pod::Spec.new do |m|
   m.preserve_path = '**/*.bcsymbolmap'
 
   m.dependency "MapboxMobileEvents", "~> 0.10.4"
+
+  m.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64 arm64e' }
+ 
+  m.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64 arm64e' }
+
 end


### PR DESCRIPTION
Due to issues building to the simulator Xcode 12, I have added the following two lines to our podspec to ensure that arm64 and arm64e simulators are excluded:
```
m.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
m.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
```
