### PR TITLE
Fix frame-delay bug affect UIViews.

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
-## 6.2.1 - September 23, 2020
+## master
 
 ### 🐞 Bug fixes
+
+* Fixed a bug with UIViews being incorrectly updated with a one frame delay. ([#483](https://github.com/mapbox/mapbox-gl-native-ios/pull/483))
+
+## 6.2.1 - September 23, 2020
 
 * Fixed an issue where completion blocks were not called until the map was rendered. ([#463](https://github.com/mapbox/mapbox-gl-native-ios/pull/463))
 * Fixed an issue that caused a crash when custom location managers did not implement `MGLLocationManager.accuracyAuthorization`. ([#474](https://github.com/mapbox/mapbox-gl-native-ios/pull/474))

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1099,7 +1099,7 @@ public:
     }
 }
 
-- (void)updateViewsPostMapRendering {
+- (void)updateViewsWithCurrentUpdateParameters {
     // Update UIKit elements, prior to rendering
     [self updateUserLocationAnnotationView];
     [self updateAnnotationViews];
@@ -1120,6 +1120,19 @@ public:
 
     if (!self.dormant && needsRender)
     {
+        // It's important to call this *before* `_rendererFrontend->render()`, as
+        // that function saves the current `updateParameters` before rendering. If this
+        // occurs after then the views will be a frame behind.
+        //
+        // The update parameters will have been updated earlier, for example by
+        // calls to easeTo, flyTo, called from gesture handlers.
+        
+        MGL_SIGNPOST_BEGIN(_log, _signpost, "renderSync", "update");
+        [self updateViewsWithCurrentUpdateParameters];
+        MGL_SIGNPOST_END(_log, _signpost, "renderSync", "update");
+
+        // - - - - -
+
         MGL_SIGNPOST_BEGIN(_log, _signpost, "renderSync", "render");
         if (_rendererFrontend) {
             _numberOfRenderCalls++;
@@ -1136,15 +1149,6 @@ public:
             }
         }
         MGL_SIGNPOST_END(_log, _signpost, "renderSync", "render");
-
-        // - - - - -
-
-        // TODO: This should be moved from what's essentially the UIView rendering
-        // To do this, add view models that can be updated separately, before the
-        // UIViews can be updated to match
-        MGL_SIGNPOST_BEGIN(_log, _signpost, "renderSync", "update");
-        [self updateViewsPostMapRendering];
-        MGL_SIGNPOST_END(_log, _signpost, "renderSync", "update");
     }
 
     if (hasPendingBlocks) {


### PR DESCRIPTION
Fixes #480 

This PR fixes a frame-delay bug with UIViews - for example, annotation views.

Because of https://github.com/mapbox/mapbox-gl-native-ios/blob/0d7e8a784aab90010794c5050259380b9e34f07f/platform/darwin/src/MGLRendererFrontend.h#L56 it's important to update the UIViews' positions before calling render. Updates have *already* occurred by this point, for example from gesture handlers. 