### PR TITLE
Prepare to use main as the primary branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ If you want to contribute code:
 
 1. Ensure that existing [pull requests](https://github.com/mapbox/mapbox-gl-native-ios/pulls) and [issues](https://github.com/mapbox/mapbox-gl-native-ios/issues) don’t already cover your contribution or question.
 
-1. Pull requests are gladly accepted. If there are any changes that developers using one of the GL SDKs should be aware of, please update the **master** section of the relevant changelog(s):
+1. Pull requests are gladly accepted. If there are any changes that developers using one of the GL SDKs should be aware of, please update the **main** section of the relevant changelog(s):
   * [Mapbox Maps SDK for iOS](platform/ios/CHANGELOG.md)
   * [Mapbox Maps SDK for macOS](platform/macos/CHANGELOG.md)
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 export BUILDTYPE ?= Debug
 export IS_LOCAL_DEVELOPMENT ?= true
-export TARGET_BRANCH ?= master
+export TARGET_BRANCH ?= main
 
 CMAKE ?= cmake
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ The Mapbox Maps SDK for iOS is an open-source framework for embedding interactiv
 
 | SDK                                     | Languages                          | Build status                             |
 | --------------------------------------- | ---------------------------------- | ---------------------------------------- |
-| [Mapbox Maps SDK for iOS](platform/ios/)         | Objective-C or Swift               | [![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native-ios.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native-ios/tree/master) |
-| [Mapbox Maps SDK for macOS](platform/macos/)     | Objective-C, Swift, or AppleScript | [![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native-ios.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native-ios/tree/master) |
+| [Mapbox Maps SDK for iOS](platform/ios/)         | Objective-C or Swift               | [![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native-ios.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native-ios/tree/main) |
+| [Mapbox Maps SDK for macOS](platform/macos/)     | Objective-C, Swift, or AppleScript | [![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native-ios.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native-ios/tree/main) |
 
 ## License
 

--- a/circle.yml
+++ b/circle.yml
@@ -42,7 +42,7 @@ workflows:
             - ios-release
           filters:
             branches:
-              only: master
+              only: main
 
       # - macos-debug
   nightly:
@@ -52,7 +52,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       - ios-build:
           matrix:
@@ -103,9 +103,9 @@ commands:
           echo "$CIRCLE_SHA1"
           echo "$CIRCLE_SHA1" > .circle-sha1
           echo "$CIRCLE_TARGET_BRANCH"
-          echo "${CIRCLE_TARGET_BRANCH:master}" > .circle-target-branch
+          echo "${CIRCLE_TARGET_BRANCH:main}" > .circle-target-branch
           echo "$CIRCLE_MERGE_BASE"
-          echo "${CIRCLE_MERGE_BASE:master}" > .circle-merge-base
+          echo "${CIRCLE_MERGE_BASE:main}" > .circle-merge-base
           ccache --clear
   reset-ccache-stats:
     steps:
@@ -246,7 +246,7 @@ commands:
           name: Trigger metrics
           command: |
             if [ -n "${MOBILE_METRICS_TOKEN}" ]; then
-              bash -c "curl -X POST --header \"Content-Type: application/json\" --data '{\"parameters\": {\"run_ios_maps_benchmark\": true, \"ci_ref\": $CIRCLE_BUILD_NUM }, \"branch\": \"master\" }' https://circleci.com/api/v2/project/github/mapbox/mobile-metrics/pipeline?circle-token=${MOBILE_METRICS_TOKEN}"
+              bash -c "curl -X POST --header \"Content-Type: application/json\" --data '{\"parameters\": {\"run_ios_maps_benchmark\": true, \"ci_ref\": $CIRCLE_BUILD_NUM }, \"branch\": \"main\" }' https://circleci.com/api/v2/project/github/mapbox/mobile-metrics/pipeline?circle-token=${MOBILE_METRICS_TOKEN}"
             else
               echo "MOBILE_METRICS_TOKEN not provided"
             fi
@@ -270,7 +270,7 @@ commands:
     steps:
     - slack/status:
         fail_only: true
-        only_for_branches: 'internal,master'
+        only_for_branches: 'internal,main'
         include_visit_job_action: true
         failure_message: ':red_circle: Job \`$CIRCLE_JOB\` <$CIRCLE_BUILD_URL|failed>.'
 
@@ -292,7 +292,7 @@ commands:
     - run:
         name: Check if this job can be skipped
         command: |
-          if [[ $CIRCLE_BRANCH != master ]] && [[ $CIRCLE_BRANCH != release-* ]] && [[ -z $CIRCLE_TAG ]]; then
+          if [[ $CIRCLE_BRANCH != main ]] && [[ $CIRCLE_BRANCH != release-* ]] && [[ -z $CIRCLE_TAG ]]; then
             scripts/check-ci-job-skippability.js
           fi
 
@@ -438,13 +438,13 @@ jobs:
       - deploy:
           name: Upload snapshot build to s3
           command: |
-            if [[ $CIRCLE_BRANCH == master ]]; then
+            if [[ $CIRCLE_BRANCH == main ]]; then
               platform/ios/scripts/deploy-snapshot.sh
             fi
 #      - deploy:
 #          name: Deploy to Mapbox CocoaPods spec repo
 #          command: |
-#            if [[ $CIRCLE_BRANCH == master ]]; then
+#            if [[ $CIRCLE_BRANCH == main ]]; then
 #              platform/ios/scripts/deploy-to-cocoapods.sh
 #            fi
       - run:

--- a/platform/darwin/README.md
+++ b/platform/darwin/README.md
@@ -2,8 +2,8 @@
 
 The code in the Darwin platform targets Apple platforms but is not specific
 to iOS or macOS. This code is not distributed as an SDK in itself, but is required
-by the [Mapbox iOS SDK](https://github.com/mapbox/mapbox-gl-native-ios/tree/master/platform/ios)
-and [Mapbox macOS SDK](https://github.com/mapbox/mapbox-gl-native-ios/tree/master/platform/macos).
+by the [Mapbox iOS SDK](https://github.com/mapbox/mapbox-gl-native-ios/tree/main/platform/ios)
+and [Mapbox macOS SDK](https://github.com/mapbox/mapbox-gl-native-ios/tree/main/platform/macos).
 
 These files depend on the Foundation and Core Foundation frameworks but do not
 depend on iOS- or macOS–specific frameworks, such as UIKit or AppKit. Any

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
-## master
+## main
 
 ### 🐞 Bug fixes
 

--- a/platform/ios/README.md
+++ b/platform/ios/README.md
@@ -1,6 +1,6 @@
 # [Mapbox Maps SDK for iOS](https://docs.mapbox.com/ios/maps/)
 
-[![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native-ios.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native-ios/tree/master)
+[![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native-ios.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native-ios/tree/main)
 
 A library based on Mapbox GL Native for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS using Objective-C, Swift, or Interface Builder.
 

--- a/platform/ios/docs/pod-README.md
+++ b/platform/ios/docs/pod-README.md
@@ -2,9 +2,9 @@
 
 The Mapbox Maps SDK for iOS is an open-source framework for embedding interactive map views with scalable, customizable vector maps into Cocoa Touch applications on iOS 9.0 and above using Objective-C, Swift, or Interface Builder. It takes stylesheets that conform to the [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/), applies them to vector tiles that conform to the [Mapbox Vector Tile Specification](https://www.mapbox.com/developers/vector-tiles/), and renders them using OpenGL.
 
-For more information, check out the [Mapbox Maps SDK for iOS homepage](https://www.mapbox.com/ios-sdk/) and the [full changelog](https://github.com/mapbox/mapbox-gl-native-ios/blob/master/platform/ios/CHANGELOG.md) online.
+For more information, check out the [Mapbox Maps SDK for iOS homepage](https://www.mapbox.com/ios-sdk/) and the [full changelog](https://github.com/mapbox/mapbox-gl-native-ios/blob/main/platform/ios/CHANGELOG.md) online.
 
-[![](https://raw.githubusercontent.com/mapbox/mapbox-gl-native-ios/master/platform/ios/docs/img/screenshot.png)]()
+[![](https://raw.githubusercontent.com/mapbox/mapbox-gl-native-ios/main/platform/ios/docs/img/screenshot.png)]()
 
 ## Installation
 

--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -3,7 +3,7 @@ author: Mapbox
 author_url: https://www.mapbox.com/
 github_url: https://github.com/mapbox/mapbox-gl-native-ios
 dash_url: https://docs.mapbox.com/ios/docsets/Mapbox.xml
-copyright: '© 2014–2019 [Mapbox](https://www.mapbox.com/). See [license](https://github.com/mapbox/mapbox-gl-native-ios/blob/master/LICENSE.md) for more details.'
+copyright: '© 2014–2019 [Mapbox](https://www.mapbox.com/). See [license](https://github.com/mapbox/mapbox-gl-native-ios/blob/main/LICENSE.md) for more details.'
 
 head: |
   <link rel='shortcut icon' href='https://www.mapbox.com/img/favicon.ico' type='image/x-icon' />

--- a/platform/ios/scripts/install-packaging-dependencies.sh
+++ b/platform/ios/scripts/install-packaging-dependencies.sh
@@ -54,7 +54,7 @@ if [[ -z `which jazzy` || $(jazzy -v) != "jazzy version: ${JAZZY_VERSION}" ]]; t
     fi
 
     if [ -z `which jazzy` ]; then
-        echo "Unable to install jazzy ($JAZZY_VERSION). See https://github.com/mapbox/mapbox-gl-native-ios/blob/master/platform/ios/INSTALL.md"
+        echo "Unable to install jazzy ($JAZZY_VERSION). See https://github.com/mapbox/mapbox-gl-native-ios/blob/main/platform/ios/INSTALL.md"
         exit 1
     fi
 else

--- a/platform/ios/scripts/metrics.sh
+++ b/platform/ios/scripts/metrics.sh
@@ -18,7 +18,7 @@ scripts/check_binary_size.js "build/ios/pkg/dynamic/Mapbox-stripped-x86_64"  "iO
 # Track overall library size
 scripts/check_binary_size.js "build/ios/pkg/dynamic/Mapbox-stripped"         "iOS Dynamic"
 
-if [[ $CIRCLE_BRANCH == master ]]; then
+if [[ $CIRCLE_BRANCH == main ]]; then
   # Build source data for http://mapbox.github.io/mapbox-gl-native/metrics/binary-size/
   # and log binary sizes to metrics warehouse
   scripts/publish_binary_size.js

--- a/platform/ios/scripts/release-notes.js
+++ b/platform/ios/scripts/release-notes.js
@@ -63,7 +63,7 @@ const bestReleaseNotesForCurrentVersion = semver.minSatisfying(versionsInRelease
 const currentReleaseNotes = _.find(releaseNotes, { version: bestReleaseNotesForCurrentVersion });
 
 if (!currentReleaseNotes) {
-    console.error('Could not find a release section satisfying %s in %s — did you forget to rename the "master" section to %s?', currentVersion, changelogPath, currentVersion.split("-")[0]);
+    console.error('Could not find a release section satisfying %s in %s — did you forget to rename the "main" section to %s?', currentVersion, changelogPath, currentVersion.split("-")[0]);
     process.exit(1);
 }
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for Mapbox Maps SDK for macOS
 
-## master
+## main
 
 * `MGLMapSnapshotOptions` to respect `showsLogo`. ([#335](https://github.com/mapbox/mapbox-gl-native-ios/issues/335))
 

--- a/platform/macos/README.md
+++ b/platform/macos/README.md
@@ -1,6 +1,6 @@
 # [Mapbox Maps SDK for macOS](https://mapbox.github.io/mapbox-gl-native/macos/)
 
-[![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native-ios.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native-ios/tree/master)
+[![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native-ios.svg?style=shield)](https://circleci.com/gh/mapbox/workflows/mapbox-gl-native-ios/tree/main)
 
 Put interactive, scalable world maps into your native Cocoa application with the Mapbox Maps SDK for macOS.
 

--- a/platform/macos/docs/doc-README.md
+++ b/platform/macos/docs/doc-README.md
@@ -1,9 +1,9 @@
-# [Mapbox Maps SDK for macOS](https://github.com/mapbox/mapbox-gl-native-ios/tree/master/platform/macos/)
+# [Mapbox Maps SDK for macOS](https://github.com/mapbox/mapbox-gl-native-ios/tree/main/platform/macos/)
 
 The Mapbox Maps SDK for macOS is an open-source framework for embedding interactive map views with scalable, customizable vector maps into Cocoa applications on macOS 10.11.0 and above using Objective-C, Swift, Interface Builder, or AppleScript. The SDK takes stylesheets that conform to the [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/), applies them to vector tiles that conform to the [Mapbox Vector Tile Specification](https://www.mapbox.com/developers/vector-tiles/), and renders them using OpenGL.
 
 ![](img/screenshot.jpg)
 
-For setup information, consult the README.md that comes with this documentation. For further instructions, consult the [Mapbox Maps SDK for macOS documentation](https://mapbox.github.io/mapbox-gl-native-ios/macos/). The [Mapbox Maps SDK for iOS](https://www.mapbox.com/ios-sdk/) has [API documentation](https://www.mapbox.com/ios-sdk/api/) and [online examples](https://www.mapbox.com/ios-sdk/examples/) that apply to the macOS SDK with few differences, mostly around unimplemented features like user location tracking. A [full changelog](https://github.com/mapbox/mapbox-gl-native-ios/blob/master/platform/macos/CHANGELOG.md) is also available.
+For setup information, consult the README.md that comes with this documentation. For further instructions, consult the [Mapbox Maps SDK for macOS documentation](https://mapbox.github.io/mapbox-gl-native-ios/macos/). The [Mapbox Maps SDK for iOS](https://www.mapbox.com/ios-sdk/) has [API documentation](https://www.mapbox.com/ios-sdk/api/) and [online examples](https://www.mapbox.com/ios-sdk/examples/) that apply to the macOS SDK with few differences, mostly around unimplemented features like user location tracking. A [full changelog](https://github.com/mapbox/mapbox-gl-native-ios/blob/main/platform/macos/CHANGELOG.md) is also available.
 
 Mapbox does not officially support the macOS SDK to the same extent as the iOS SDK; however, [bug reports and pull requests](https://github.com/mapbox/mapbox-gl-native-ios/issues/) are certainly welcome.

--- a/platform/macos/docs/pod-README.md
+++ b/platform/macos/docs/pod-README.md
@@ -1,4 +1,4 @@
-# [Mapbox Maps SDK for macOS](https://github.com/mapbox/mapbox-gl-native-ios/tree/master/platform/macos/)
+# [Mapbox Maps SDK for macOS](https://github.com/mapbox/mapbox-gl-native-ios/tree/main/platform/macos/)
 
 Put interactive, scalable world maps into your native Cocoa application with the open-source Mapbox Maps SDK for macOS.
 
@@ -8,7 +8,7 @@ Put interactive, scalable world maps into your native Cocoa application with the
 * A well-designed, fully documented API helps you stay productive.
 * Develop across [multiple platforms](https://www.mapbox.com/maps/), including [iOS](https://docs.mapbox.com/ios/maps/), using the same styles and similar APIs.
 
-![](https://raw.githubusercontent.com/mapbox/mapbox-gl-native-ios/master/platform/macos/docs/img/screenshot.jpg)
+![](https://raw.githubusercontent.com/mapbox/mapbox-gl-native-ios/main/platform/macos/docs/img/screenshot.jpg)
 
 The Mapbox Maps SDK for macOS is compatible with macOS 10.11.0 and above for Cocoa applications developed in Objective-C, Swift, Interface Builder, or AppleScript. For hybrid applications, consider [Mapbox GL JS](https://www.mapbox.com/mapbox-gl-js/).
 

--- a/platform/macos/jazzy.yml
+++ b/platform/macos/jazzy.yml
@@ -3,7 +3,7 @@ author: Mapbox
 author_url: https://www.mapbox.com/
 github_url: https://github.com/mapbox/mapbox-gl-native-ios
 dash_url: https://mapbox.github.io/mapbox-gl-native/macos/docsets/Mapbox.xml
-copyright: '© 2014–2019 [Mapbox](https://www.mapbox.com/). See [license](https://github.com/mapbox/mapbox-gl-native-ios/blob/master/LICENSE.md) for more details.'
+copyright: '© 2014–2019 [Mapbox](https://www.mapbox.com/). See [license](https://github.com/mapbox/mapbox-gl-native-ios/blob/main/LICENSE.md) for more details.'
 
 head: |
   <link rel='shortcut icon' href='https://www.mapbox.com/img/favicon.ico' type='image/x-icon' />

--- a/platform/macos/scripts/document.sh
+++ b/platform/macos/scripts/document.sh
@@ -8,7 +8,7 @@ if [ -z `which jazzy` ]; then
     echo "Installing jazzy…"
     gem install jazzy
     if [ -z `which jazzy` ]; then
-        echo "Unable to install jazzy. See https://github.com/mapbox/mapbox-gl-native-ios/blob/master/platform/macos/INSTALL.md"
+        echo "Unable to install jazzy. See https://github.com/mapbox/mapbox-gl-native-ios/blob/main/platform/macos/INSTALL.md"
         exit 1
     fi
 fi
@@ -24,7 +24,7 @@ mkdir -p /tmp/mbgl/
 README=/tmp/mbgl/README.md
 if [[ ${STANDALONE:-} ]]; then
     cp platform/macos/docs/pod-README.md "${README}"
-    perl -pi -e 's|https://raw.githubusercontent.com/mapbox/mapbox-gl-native-ios/master/platform/macos/docs/||' \
+    perl -pi -e 's|https://raw.githubusercontent.com/mapbox/mapbox-gl-native-ios/main/platform/macos/docs/||' \
         "${README}"
 else
     cp platform/macos/docs/doc-README.md "${README}"

--- a/scripts/environment.js
+++ b/scripts/environment.js
@@ -24,7 +24,7 @@ if (pr) {
 } else {
     const head = process.env['CIRCLE_SHA1'];
     for (const sha of execSync(`git rev-list --max-count=500 ${head}`).toString().trim().split('\n')) {
-        const base = execSync(`git branch -r --contains ${sha} origin/master origin/release-*`).toString().split('\n')[0].trim().replace(/^origin\//, '');
+        const base = execSync(`git branch -r --contains ${sha} origin/main origin/release-*`).toString().split('\n')[0].trim().replace(/^origin\//, '');
         if (base) {
             const mergeBase = execSync(`git merge-base origin/${base} ${head}`).toString().trim();
             console.log(`export CIRCLE_TARGET_BRANCH=${base}`);

--- a/scripts/publish_binary_size.js
+++ b/scripts/publish_binary_size.js
@@ -55,8 +55,8 @@ function query(after) {
             accept: 'application/vnd.github.antiope-preview'
         },
         query: `query {
-              repository(owner: "mapbox", name: "mapbox-gl-native") {
-                ref(qualifiedName: "master") {
+              repository(owner: "mapbox", name: "mapbox-gl-native-ios") {
+                ref(qualifiedName: "main") {
                   target {
                     ... on Commit {
                       history(first: 100, before: "36c6a8ea79bbd2596abb58ffb58debf65a4ea13d" ${after ? `, after: "${after}"` : ''}) {

--- a/scripts/publish_doxygen_coverage.js
+++ b/scripts/publish_doxygen_coverage.js
@@ -67,7 +67,7 @@ github.apps.createInstallationToken({installation_id: SIZE_CHECK_APP_INSTALLATIO
             }
         })];
 
-        if (process.env['CIRCLE_BRANCH'] === 'master') {
+        if (process.env['CIRCLE_BRANCH'] === 'main') {
             promises.push(new AWS.S3({region: 'us-east-1'}).putObject({
                 Body: zlib.gzipSync(JSON.stringify({
                     'created_at': date,


### PR DESCRIPTION
This PR:
- Prepares CI for when we switch the primary branch to `main`.
- Updates relevant links and references from `master` to `main`.

 