### PR TITLE
Update MapboxMobileEvents to v10.5.0-beta.2

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps-gl-core/mapbox-ios-sdk-gl-core-static.json" == 5.1.0
-github "mapbox/mapbox-events-ios" ~> 0.10.4
+github "mapbox/mapbox-events-ios" ~> 0.10.5-beta.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps-gl-core/mapbox-ios-sdk-gl-core-static.json" "5.1.0"
-github "mapbox/mapbox-events-ios" "v0.10.4"
+github "mapbox/mapbox-events-ios" "v0.10.5-beta.2"


### PR DESCRIPTION
This PR updates the Mapbox Mobile Events library to v10.5.0-beta.2.