### PR TITLE
Add compass image as a sublayer

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ workflows:
       - ios-build:
           matrix:
             parameters:
-              xcode: ["11.1.0", "12.0.0"]
+              xcode: ["11.7.0", "12.0.0"]
               buildtype: ["Debug", "Release"]
       - ios-release-template:
           xcode: "12.0.0"
@@ -57,7 +57,7 @@ workflows:
       - ios-build:
           matrix:
             parameters:
-              xcode: ["11.3.1", "11.7.0", "12.2.0"]
+              xcode: ["11.1.0", "11.3.1", "12.2.0"]
               buildtype: ["Debug", "Release"]
       - ios-sanitize-nightly:
           requires:

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ workflows:
       - ios-build:
           matrix:
             parameters:
-              xcode: ["11.1.0", "11.7.0"]
+              xcode: ["11.1.0", "12.0.0"]
               buildtype: ["Debug", "Release"]
       - ios-release-template:
           xcode: "12.0.0"
@@ -57,7 +57,7 @@ workflows:
       - ios-build:
           matrix:
             parameters:
-              xcode: ["11.3.1", "11.5.0", "11.6.0", "12.0.0"]
+              xcode: ["11.3.1", "11.7.0", "12.2.0"]
               buildtype: ["Debug", "Release"]
       - ios-sanitize-nightly:
           requires:

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,14 +4,19 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ## 6.3.0
 
+### 🐞 Bug fixes
+
+* Partly fixed an issue on iOS 14 where `-[UIView layoutSubviews]` was being repeatedly called. ([#501](https://github.com/mapbox/mapbox-gl-native-ios/pull/501))
+* Fixed a bug with UIViews being incorrectly updated with a one frame delay. ([#483](https://github.com/mapbox/mapbox-gl-native-ios/pull/483))
+* Fixed an issue where CocoaPods users could not install the SDK when using Xcode 12. ([#482](https://github.com/mapbox/mapbox-gl-native-ios/pull/482))
+
 ### 🔧 Dependencies
 
 * Updated `mapbox-events-ios` to `0.10.5-beta.2` in order to add additional iOS 14 support.([#491](https://github.com/mapbox/mapbox-gl-native-ios/pull/491))
 
-### 🐞 Bug fixes
+### ✨ Other changes
 
-* Fixed a bug with UIViews being incorrectly updated with a one frame delay. ([#483](https://github.com/mapbox/mapbox-gl-native-ios/pull/483))
-* Fixed an issue where CocoaPods users could not install the SDK when using Xcode 12. ([#482](https://github.com/mapbox/mapbox-gl-native-ios/pull/482))
+* The default branch is now `main`. Please rebase any existing branches you may have. ([#489](https://github.com/mapbox/mapbox-gl-native-ios/pull/489))
 
 ## 6.2.1 - September 23, 2020
 

--- a/platform/ios/src/MGLCompassButton.mm
+++ b/platform/ios/src/MGLCompassButton.mm
@@ -12,6 +12,7 @@
 @interface MGLCompassButton ()
 
 @property (nonatomic, weak) MGLMapView *mapView;
+@property (nonatomic) CALayer *imageLayer;
 @property (nonatomic) MGLCompassDirectionFormatter *accessibilityCompassFormatter;
 
 @end
@@ -31,7 +32,14 @@
 }
 
 - (void)commonInit {
-    self.image = self.compassImage;
+    UIImage *image = self.compassImage;
+    CGRect bounds = (CGRect){CGPointZero, image.size};
+    self.bounds = bounds;
+
+    self.imageLayer = [[CALayer alloc] init];
+    self.imageLayer.frame = bounds;
+    self.imageLayer.contents = (id)image.CGImage;
+    [self.layer addSublayer:self.imageLayer];
 
     self.compassVisibility = MGLOrnamentVisibilityAdaptive;
 
@@ -48,8 +56,6 @@
 
     self.accessibilityCompassFormatter = [[MGLCompassDirectionFormatter alloc] init];
     self.accessibilityCompassFormatter.unitStyle = NSFormattingUnitStyleLong;
-
-    [self sizeToFit];
 }
 
 - (void)setCompassVisibility:(MGLOrnamentVisibility)compassVisibility {
@@ -96,7 +102,8 @@
 - (void)updateCompassAnimated:(BOOL)animated {
     CLLocationDirection direction = self.mapView.direction;
     CLLocationDirection plateDirection = mbgl::util::wrap(-direction, 0., 360.);
-    self.transform = CGAffineTransformMakeRotation(MGLRadiansFromDegrees(plateDirection));
+
+    self.imageLayer.transform = CATransform3DMakeRotation(MGLRadiansFromDegrees(plateDirection), 0.0, 0.0, 1.0);
 
     self.isAccessibilityElement = direction > 0;
     self.accessibilityValue = [self.accessibilityCompassFormatter stringFromDirection:direction];

--- a/platform/ios/src/MGLCompassButton.mm
+++ b/platform/ios/src/MGLCompassButton.mm
@@ -31,6 +31,10 @@
     return self;
 }
 
+- (void)setImage:(UIImage *)image {
+    self.imageLayer.contents = (id)image.CGImage;
+}
+
 - (void)commonInit {
     UIImage *image = self.compassImage;
     CGRect bounds = (CGRect){CGPointZero, image.size};
@@ -38,7 +42,9 @@
 
     self.imageLayer = [[CALayer alloc] init];
     self.imageLayer.frame = bounds;
-    self.imageLayer.contents = (id)image.CGImage;
+    self.imageLayer.contentsGravity = kCAGravityResizeAspect;
+
+    self.image = image;
     [self.layer addSublayer:self.imageLayer];
 
     self.compassVisibility = MGLOrnamentVisibilityAdaptive;
@@ -103,7 +109,10 @@
     CLLocationDirection direction = self.mapView.direction;
     CLLocationDirection plateDirection = mbgl::util::wrap(-direction, 0., 360.);
 
+    [CATransaction begin];
+    [CATransaction setValue:@(YES) forKey:kCATransactionDisableActions];
     self.imageLayer.transform = CATransform3DMakeRotation(MGLRadiansFromDegrees(plateDirection), 0.0, 0.0, 1.0);
+    [CATransaction commit];
 
     self.isAccessibilityElement = direction > 0;
     self.accessibilityValue = [self.accessibilityCompassFormatter stringFromDirection:direction];

--- a/platform/ios/src/MGLCompassButton_Private.h
+++ b/platform/ios/src/MGLCompassButton_Private.h
@@ -11,6 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)compassButtonWithMapView:(MGLMapView *)mapView;
 
 @property (nonatomic, weak) MGLMapView *mapView;
+@property (nonatomic) CALayer *imageLayer;
 
 - (void)updateCompass;
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -7269,7 +7269,10 @@ static void *windowScreenContext = &windowScreenContext;
 
 - (void)updateCompass
 {
-    [self.compassView updateCompass];
+    if ((self.compassView.compassVisibility != MGLOrnamentVisibilityHidden) &&
+        (!self.compassView.isHidden)) {
+        [self.compassView updateCompass];
+    }
 }
 
 - (void)updateScaleBar


### PR DESCRIPTION
Fixes #500 

Changing the transform on the compass button triggers `-[UIView layoutSubviews]` on iOS 14. This PR add a sublayer for the compass image, keeping the original UIView's transform intact.

The original issue in #500 is not fully resolved however, as the scale bar causes a similar issue (to a lesser extent).
