### PR TITLE
[ios] Add glyphs rasterization options

### DIFF
--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -14,7 +14,7 @@
 #import "MGLStyle_Private.h"
 #import "MGLAttributionInfo_Private.h"
 #import "MGLLoggingConfiguration_Private.h"
-#import "MGLRendererConfiguration.h"
+#import "MGLRendererConfiguration_Private.h"
 #import "MGLMapSnapshotter_Private.h"
 
 #if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
@@ -725,24 +725,9 @@ NSArray<MGLAttributionInfo *> *MGLAttributionInfosFromAttributions(mbgl::MapSnap
                    .withAssetPath(NSBundle.mainBundle.resourceURL.path.UTF8String);
 
     // Create the snapshotter
-    mbgl::optional<std::string> localFontFamilyName = config.localFontFamilyName ? mbgl::optional<std::string>(std::string(config.localFontFamilyName.UTF8String)) : mbgl::nullopt;
-    mbgl::GlyphsRasterizationOptions glyphsRasterizationOptions;
-    glyphsRasterizationOptions.fontFamily = localFontFamilyName;
-    switch (config.glyphsRasterizationMode) {
-        case MGLNoGlyphsRasterizedLocally:
-            glyphsRasterizationOptions.rasterizationMode = mbgl::GlyphsRasterizationMode::NoGlyphsRasterizedLocally;
-            break;
-        case MGLIdeographsRasterizedLocally:
-            glyphsRasterizationOptions.rasterizationMode = mbgl::GlyphsRasterizationMode::IdeographsRasterizedLocally;
-            break;
-        case MGLAllGlyphsRasterizedLocally:
-            glyphsRasterizationOptions.rasterizationMode = mbgl::GlyphsRasterizationMode::AllGlyphsRasterizedLocally;
-            break;
-    }
-
     _delegateHost = std::make_unique<MGLMapSnapshotterDelegateHost>(self);
     _mbglMapSnapshotter = std::make_unique<mbgl::MapSnapshotter>(
-                                                                 size, pixelRatio, resourceOptions, *_delegateHost, glyphsRasterizationOptions);
+                                                                 size, pixelRatio, resourceOptions, *_delegateHost, config.glyphsRasterizationOptions);
     
     _mbglMapSnapshotter->setStyleURL(std::string(options.styleURL.absoluteString.UTF8String));
     

--- a/platform/darwin/src/MGLMapSnapshotter.mm
+++ b/platform/darwin/src/MGLMapSnapshotter.mm
@@ -726,9 +726,23 @@ NSArray<MGLAttributionInfo *> *MGLAttributionInfosFromAttributions(mbgl::MapSnap
 
     // Create the snapshotter
     mbgl::optional<std::string> localFontFamilyName = config.localFontFamilyName ? mbgl::optional<std::string>(std::string(config.localFontFamilyName.UTF8String)) : mbgl::nullopt;
+    mbgl::GlyphsRasterizationOptions glyphsRasterizationOptions;
+    glyphsRasterizationOptions.fontFamily = localFontFamilyName;
+    switch (config.glyphsRasterizationMode) {
+        case MGLNoGlyphsRasterizedLocally:
+            glyphsRasterizationOptions.rasterizationMode = mbgl::GlyphsRasterizationMode::NoGlyphsRasterizedLocally;
+            break;
+        case MGLIdeographsRasterizedLocally:
+            glyphsRasterizationOptions.rasterizationMode = mbgl::GlyphsRasterizationMode::IdeographsRasterizedLocally;
+            break;
+        case MGLAllGlyphsRasterizedLocally:
+            glyphsRasterizationOptions.rasterizationMode = mbgl::GlyphsRasterizationMode::AllGlyphsRasterizedLocally;
+            break;
+    }
+
     _delegateHost = std::make_unique<MGLMapSnapshotterDelegateHost>(self);
     _mbglMapSnapshotter = std::make_unique<mbgl::MapSnapshotter>(
-                                                                 size, pixelRatio, resourceOptions, *_delegateHost, localFontFamilyName);
+                                                                 size, pixelRatio, resourceOptions, *_delegateHost, glyphsRasterizationOptions);
     
     _mbglMapSnapshotter->setStyleURL(std::string(options.styleURL.absoluteString.UTF8String));
     

--- a/platform/darwin/src/MGLRendererConfiguration.h
+++ b/platform/darwin/src/MGLRendererConfiguration.h
@@ -5,12 +5,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Indicates how the map view load glyphs.
 typedef NS_ENUM(NSUInteger, MGLGlyphsRasterizationMode) {
+    /// The MGLGlyphsRasterizationMode was unset .
+    MGLGlyphsRasterizationModeNone,
     /// No glyphs are rasterized locally. All glyphs are loaded from the server.
-    MGLNoGlyphsRasterizedLocally = 0,
+    MGLGlyphsRasterizationModeIdeographsRasterizedLocally,
     /// Ideographs are rasterized locally, and they are not loaded from the server.
-    MGLIdeographsRasterizedLocally,
+    MGLGlyphsRasterizationModeNoGlyphsRasterizedLocally,
     /// All glyphs are rasterized locally. No glyphs are loaded from the server.
-    MGLAllGlyphsRasterizedLocally
+    MGLGlyphsRasterizationModeAllGlyphsRasterizedLocally
 };
 
 /**

--- a/platform/darwin/src/MGLRendererConfiguration.h
+++ b/platform/darwin/src/MGLRendererConfiguration.h
@@ -5,11 +5,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Indicates how the map view load glyphs.
 typedef NS_ENUM(NSUInteger, MGLGlyphsRasterizationMode) {
-    /// The MGLGlyphsRasterizationMode was unset .
+    /// The MGLGlyphsRasterizationMode was unset.
     MGLGlyphsRasterizationModeNone,
-    /// No glyphs are rasterized locally. All glyphs are loaded from the server.
-    MGLGlyphsRasterizationModeIdeographsRasterizedLocally,
     /// Ideographs are rasterized locally, and they are not loaded from the server.
+    MGLGlyphsRasterizationModeIdeographsRasterizedLocally,
+    /// No glyphs are rasterized locally. All glyphs are loaded from the server.
     MGLGlyphsRasterizationModeNoGlyphsRasterizedLocally,
     /// All glyphs are rasterized locally. No glyphs are loaded from the server.
     MGLGlyphsRasterizationModeAllGlyphsRasterizedLocally

--- a/platform/darwin/src/MGLRendererConfiguration.h
+++ b/platform/darwin/src/MGLRendererConfiguration.h
@@ -4,7 +4,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// Indicates how the map view load glyphs.
-typedef NS_ENUM(NSUInteger, MGLGlyphsRasterizationMode) {
+typedef NS_CLOSED_ENUM(NSUInteger, MGLGlyphsRasterizationMode) {
     /// The MGLGlyphsRasterizationMode was unset.
     MGLGlyphsRasterizationModeNone,
     /// Ideographs are rasterized locally, and they are not loaded from the server.

--- a/platform/darwin/src/MGLRendererConfiguration.h
+++ b/platform/darwin/src/MGLRendererConfiguration.h
@@ -3,6 +3,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// Indicates how the map view load glyphs.
+typedef NS_ENUM(NSUInteger, MGLGlyphsRasterizationMode) {
+    /// No glyphs are rasterized locally. All glyphs are loaded from the server.
+    MGLNoGlyphsRasterizedLocally = 0,
+    /// Ideographs are rasterized locally, and they are not loaded from the server.
+    MGLIdeographsRasterizedLocally,
+    /// All glyphs are rasterized locally. No glyphs are loaded from the server.
+    MGLAllGlyphsRasterizedLocally
+};
+
 /**
  The MGLRendererConfiguration object represents configuration values for the
  renderer.
@@ -50,6 +60,15 @@ MGL_EXPORT
 @property (nonatomic, readonly) BOOL perSourceCollisions;
 
 - (BOOL)perSourceCollisionsWithInfoDictionaryObject:(nullable id)infoDictionaryObject;
+
+/**
+ Indicates how the map view load glyphs.
+
+ Set `MGLGlyphsRasterizationOptions` in your containing app's Info.plist.
+ */
+@property (nonatomic, readonly) MGLGlyphsRasterizationMode glyphsRasterizationMode;
+
+- (MGLGlyphsRasterizationMode)glyphsRasterizationModeWithInfoDictionaryObject:(nullable id)infoDictionaryObject;
 
 @end
 

--- a/platform/darwin/src/MGLRendererConfiguration.m
+++ b/platform/darwin/src/MGLRendererConfiguration.m
@@ -8,6 +8,7 @@
 
 static NSString * const MGLCollisionBehaviorPre4_0Key = @"MGLCollisionBehaviorPre4_0";
 static NSString * const MGLIdeographicFontFamilyNameKey = @"MGLIdeographicFontFamilyName";
+static NSString * const MGLGlyphsRasterizationModeKey = @"MGLGlyphsRasterizationMode";
 
 @implementation MGLRendererConfiguration
 
@@ -61,6 +62,22 @@ static NSString * const MGLIdeographicFontFamilyNameKey = @"MGLIdeographicFontFa
         return [infoDictionaryObject boolValue];
     }
     return NO;
+}
+
+- (MGLGlyphsRasterizationMode)glyphsRasterizationMode {
+    id infoDictionaryObject = [NSBundle.mainBundle objectForInfoDictionaryKey:MGLGlyphsRasterizationModeKey];
+    return [self glyphsRasterizationModeWithInfoDictionaryObject:infoDictionaryObject];
+}
+
+- (MGLGlyphsRasterizationMode)glyphsRasterizationModeWithInfoDictionaryObject:(id)infoDictionaryObject {
+    if (!infoDictionaryObject || ![infoDictionaryObject isKindOfClass:[NSString class]]) {
+        return MGLNoGlyphsRasterizedLocally;
+    }
+    NSDictionary *nameOptionMap = @{@"MGLNoGlyphsRasterizedLocally":@(MGLNoGlyphsRasterizedLocally),
+                                    @"MGLIdeographsRasterizedLocally":@(MGLIdeographsRasterizedLocally),
+                                    @"MGLAllGlyphsRasterizedLocally":@(MGLAllGlyphsRasterizedLocally)};
+
+    return [nameOptionMap[infoDictionaryObject] integerValue];
 }
 
 @end

--- a/platform/darwin/src/MGLRendererConfiguration.mm
+++ b/platform/darwin/src/MGLRendererConfiguration.mm
@@ -89,8 +89,8 @@ static NSString * const MGLGlyphsRasterizationModeKey = @"MGLGlyphsRasterization
                                                                     rasterizationMode:(MGLGlyphsRasterizationMode)rasterizationMode {
     mbgl::GlyphsRasterizationOptions options;
     if (fontFamilyName == nil) {
-        if (rasterizationMode != MGLGlyphsRasterizationModeNoGlyphsRasterizedLocally || rasterizationMode != MGLGlyphsRasterizationModeNone) {
-            MGLLogError(@"The `MGLIdeographicFontFamilyName` is set to `NO`, this will make `MGLGlyphsRasterizationMode` always be `MGLNoGlyphsRasterizedLocally`.");
+        if (rasterizationMode != MGLGlyphsRasterizationModeNoGlyphsRasterizedLocally && rasterizationMode != MGLGlyphsRasterizationModeNone) {
+            MGLLogWarning(@"The `MGLIdeographicFontFamilyName` is set to `NO`, this will make `MGLGlyphsRasterizationMode` always be `MGLNoGlyphsRasterizedLocally`.");
         }
         options.rasterizationMode = mbgl::GlyphsRasterizationMode::NoGlyphsRasterizedLocally;
         return options;
@@ -108,9 +108,8 @@ static NSString * const MGLGlyphsRasterizationModeKey = @"MGLGlyphsRasterization
             options.rasterizationMode = mbgl::GlyphsRasterizationMode::AllGlyphsRasterizedLocally;
             break;
         case MGLGlyphsRasterizationModeNone:
-        default:
-            options.rasterizationMode = mbgl::GlyphsRasterizationMode::NoGlyphsRasterizedLocally;
             MGLLogWarning(@"Falling back to MGLIdeographsRasterizedLocally because  MGLIdeographicFontFamilies are specified.")
+            options.rasterizationMode = mbgl::GlyphsRasterizationMode::NoGlyphsRasterizedLocally;
             break;
     }
 

--- a/platform/darwin/src/MGLRendererConfiguration.mm
+++ b/platform/darwin/src/MGLRendererConfiguration.mm
@@ -74,8 +74,8 @@ static NSString * const MGLGlyphsRasterizationModeKey = @"MGLGlyphsRasterization
     if (!infoDictionaryObject || ![infoDictionaryObject isKindOfClass:[NSString class]]) {
         return MGLGlyphsRasterizationModeNone;
     }
-    NSDictionary *nameOptionMap = @{@"MGLNoGlyphsRasterizedLocally":@(MGLGlyphsRasterizationModeIdeographsRasterizedLocally),
-                                    @"MGLIdeographsRasterizedLocally":@(MGLGlyphsRasterizationModeNoGlyphsRasterizedLocally),
+    NSDictionary *nameOptionMap = @{@"MGLNoGlyphsRasterizedLocally":@(MGLGlyphsRasterizationModeNoGlyphsRasterizedLocally),
+                                    @"MGLIdeographsRasterizedLocally":@(MGLGlyphsRasterizationModeIdeographsRasterizedLocally),
                                     @"MGLAllGlyphsRasterizedLocally":@(MGLGlyphsRasterizationModeAllGlyphsRasterizedLocally)};
 
     return (MGLGlyphsRasterizationMode)[nameOptionMap[infoDictionaryObject] integerValue];
@@ -89,14 +89,14 @@ static NSString * const MGLGlyphsRasterizationModeKey = @"MGLGlyphsRasterization
                                                                     rasterizationMode:(MGLGlyphsRasterizationMode)rasterizationMode {
     mbgl::GlyphsRasterizationOptions options;
     if (fontFamilyName == nil) {
-        if (rasterizationMode != MGLGlyphsRasterizationModeNoGlyphsRasterizedLocally) {
+        if (rasterizationMode != MGLGlyphsRasterizationModeNoGlyphsRasterizedLocally || rasterizationMode != MGLGlyphsRasterizationModeNone) {
             MGLLogError(@"The `MGLIdeographicFontFamilyName` is set to `NO`, this will make `MGLGlyphsRasterizationMode` always be `MGLNoGlyphsRasterizedLocally`.");
         }
         options.rasterizationMode = mbgl::GlyphsRasterizationMode::NoGlyphsRasterizedLocally;
         return options;
     }
     
-    options.fontFamily =  mbgl::optional<std::string>(std::string(fontFamilyName.UTF8String));
+    options.fontFamily = std::string(fontFamilyName.UTF8String);
     switch (rasterizationMode) {
         case MGLGlyphsRasterizationModeIdeographsRasterizedLocally:
             options.rasterizationMode = mbgl::GlyphsRasterizationMode::IdeographsRasterizedLocally;
@@ -107,8 +107,10 @@ static NSString * const MGLGlyphsRasterizationModeKey = @"MGLGlyphsRasterization
         case MGLGlyphsRasterizationModeAllGlyphsRasterizedLocally:
             options.rasterizationMode = mbgl::GlyphsRasterizationMode::AllGlyphsRasterizedLocally;
             break;
+        case MGLGlyphsRasterizationModeNone:
         default:
             options.rasterizationMode = mbgl::GlyphsRasterizationMode::NoGlyphsRasterizedLocally;
+            MGLLogWarning(@"Falling back to MGLIdeographsRasterizedLocally because  MGLIdeographicFontFamilies are specified.")
             break;
     }
 

--- a/platform/darwin/src/MGLRendererConfiguration_Private.h
+++ b/platform/darwin/src/MGLRendererConfiguration_Private.h
@@ -1,0 +1,16 @@
+#import "MGLRendererConfiguration.h"
+#include <mbgl/map/glyphs_rasterization_options.hpp>
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MGLRendererConfiguration (Private)
+
+- (mbgl::GlyphsRasterizationOptions)glyphsRasterizationOptions;
+
+- (mbgl::GlyphsRasterizationOptions)glyphsRasterizationOptionsWithLocalFontFamilyName:(nullable NSString *)fontFamilyName
+                                                                    rasterizationMode:(MGLGlyphsRasterizationMode)rasterizationMode;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/test/MGLRendererConfigurationTests.m
+++ b/platform/darwin/test/MGLRendererConfigurationTests.m
@@ -159,4 +159,43 @@ static NSString * const MGLRendererConfigurationTests_collisionBehaviorKey = @"M
     }
 }
 
+- (void)testMGLGlyphsRasterizationModeWithPlistValue {
+    MGLRendererConfiguration *config = [[MGLRendererConfiguration alloc] init];
+
+    // `MGLGlyphsRasterizationMode` set to nil or not set.
+    {
+        MGLGlyphsRasterizationMode option = [config glyphsRasterizationModeWithInfoDictionaryObject:nil];
+
+        XCTAssertEqual(option, MGLNoGlyphsRasterizedLocally, @"Glyphs rasterization mode should be `MGLNoGlyphsRasterizedLocally` when it setting to nil or not set");
+    }
+
+    // `MGLGlyphsRasterizationMode` set to invalid value.
+    {
+        MGLGlyphsRasterizationMode option = [config glyphsRasterizationModeWithInfoDictionaryObject:@"invalide option value"];
+
+        XCTAssertEqual(option, MGLNoGlyphsRasterizedLocally, @"Glyphs rasterization mode should be `MGLNoGlyphsRasterizedLocally` when it setting to invalid value.");
+    }
+
+    // `MGLGlyphsRasterizationMode` set to "MGLNoGlyphsRasterizedLocally".
+    {
+        MGLGlyphsRasterizationMode option = [config glyphsRasterizationModeWithInfoDictionaryObject:@"MGLNoGlyphsRasterizedLocally"];
+
+        XCTAssertEqual(option, MGLNoGlyphsRasterizedLocally, @"Glyphs rasterization mode should be `MGLNoGlyphsRasterizedLocally`.");
+    }
+
+    // `MGLGlyphsRasterizationMode` set to "MGLIdeographsRasterizedLocally".
+    {
+        MGLGlyphsRasterizationMode option = [config glyphsRasterizationModeWithInfoDictionaryObject:@"MGLIdeographsRasterizedLocally"];
+
+        XCTAssertEqual(option, MGLIdeographsRasterizedLocally, @"Glyphs rasterization mode should be `MGLIdeographsRasterizedLocally`.");
+    }
+
+    // `MGLGlyphsRasterizationMode` set to "MGLAllGlyphsRasterizedLocally".
+    {
+        MGLGlyphsRasterizationMode option = [config glyphsRasterizationModeWithInfoDictionaryObject:@"MGLAllGlyphsRasterizedLocally"];
+
+        XCTAssertEqual(option, MGLAllGlyphsRasterizedLocally, @"Glyphs rasterization mode should be `MGLAllGlyphsRasterizedLocally`.");
+    }
+}
+
 @end

--- a/platform/darwin/test/MGLRendererConfigurationTests.mm
+++ b/platform/darwin/test/MGLRendererConfigurationTests.mm
@@ -180,14 +180,14 @@ static NSString * const MGLRendererConfigurationTests_collisionBehaviorKey = @"M
     {
         MGLGlyphsRasterizationMode mode = [config glyphsRasterizationModeWithInfoDictionaryObject:@"MGLNoGlyphsRasterizedLocally"];
 
-        XCTAssertEqual(mode, MGLGlyphsRasterizationModeIdeographsRasterizedLocally, @"Glyphs rasterization mode should be `MGLNoGlyphsRasterizedLocally`.");
+        XCTAssertEqual(mode, MGLGlyphsRasterizationModeNoGlyphsRasterizedLocally, @"Glyphs rasterization mode should be `MGLGlyphsRasterizationModeNoGlyphsRasterizedLocally`.");
     }
 
-    // `MGLGlyphsRasterizationMode` set to "MGLIdeographsRasterizedLocally".
+    // `MGLGlyphsRasterizationMode` set to "MGLGlyphsRasterizationModeIdeographsRasterizedLocally".
     {
         MGLGlyphsRasterizationMode mode = [config glyphsRasterizationModeWithInfoDictionaryObject:@"MGLIdeographsRasterizedLocally"];
 
-        XCTAssertEqual(mode, MGLGlyphsRasterizationModeNoGlyphsRasterizedLocally, @"Glyphs rasterization mode should be `MGLIdeographsRasterizedLocally`.");
+        XCTAssertEqual(mode, MGLGlyphsRasterizationModeIdeographsRasterizedLocally, @"Glyphs rasterization mode should be `MGLGlyphsRasterizationModeIdeographsRasterizedLocally`.");
     }
 
     // `MGLGlyphsRasterizationMode` set to "MGLAllGlyphsRasterizedLocally".

--- a/platform/darwin/test/MGLRendererConfigurationTests.mm
+++ b/platform/darwin/test/MGLRendererConfigurationTests.mm
@@ -1,6 +1,6 @@
 #import <Mapbox/Mapbox.h>
 #import <XCTest/XCTest.h>
-#import "MGLRendererConfiguration.h"
+#import "MGLRendererConfiguration_Private.h"
 
 static NSString * const MGLRendererConfigurationTests_collisionBehaviorKey = @"MGLCollisionBehaviorPre4_0";
 
@@ -164,37 +164,89 @@ static NSString * const MGLRendererConfigurationTests_collisionBehaviorKey = @"M
 
     // `MGLGlyphsRasterizationMode` set to nil or not set.
     {
-        MGLGlyphsRasterizationMode option = [config glyphsRasterizationModeWithInfoDictionaryObject:nil];
+        MGLGlyphsRasterizationMode mode = [config glyphsRasterizationModeWithInfoDictionaryObject:nil];
 
-        XCTAssertEqual(option, MGLNoGlyphsRasterizedLocally, @"Glyphs rasterization mode should be `MGLNoGlyphsRasterizedLocally` when it setting to nil or not set");
+        XCTAssertEqual(mode, MGLGlyphsRasterizationModeNone, @"Glyphs rasterization mode should be `MGLGlyphsRasterizationModeNone` when it setting to nil or not set");
     }
 
     // `MGLGlyphsRasterizationMode` set to invalid value.
     {
-        MGLGlyphsRasterizationMode option = [config glyphsRasterizationModeWithInfoDictionaryObject:@"invalide option value"];
+        MGLGlyphsRasterizationMode mode = [config glyphsRasterizationModeWithInfoDictionaryObject:@"invalide option value"];
 
-        XCTAssertEqual(option, MGLNoGlyphsRasterizedLocally, @"Glyphs rasterization mode should be `MGLNoGlyphsRasterizedLocally` when it setting to invalid value.");
+        XCTAssertEqual(mode, MGLGlyphsRasterizationModeNone, @"Glyphs rasterization mode should be `MGLGlyphsRasterizationModeNone` when it setting to invalid value.");
     }
 
     // `MGLGlyphsRasterizationMode` set to "MGLNoGlyphsRasterizedLocally".
     {
-        MGLGlyphsRasterizationMode option = [config glyphsRasterizationModeWithInfoDictionaryObject:@"MGLNoGlyphsRasterizedLocally"];
+        MGLGlyphsRasterizationMode mode = [config glyphsRasterizationModeWithInfoDictionaryObject:@"MGLNoGlyphsRasterizedLocally"];
 
-        XCTAssertEqual(option, MGLNoGlyphsRasterizedLocally, @"Glyphs rasterization mode should be `MGLNoGlyphsRasterizedLocally`.");
+        XCTAssertEqual(mode, MGLGlyphsRasterizationModeIdeographsRasterizedLocally, @"Glyphs rasterization mode should be `MGLNoGlyphsRasterizedLocally`.");
     }
 
     // `MGLGlyphsRasterizationMode` set to "MGLIdeographsRasterizedLocally".
     {
-        MGLGlyphsRasterizationMode option = [config glyphsRasterizationModeWithInfoDictionaryObject:@"MGLIdeographsRasterizedLocally"];
+        MGLGlyphsRasterizationMode mode = [config glyphsRasterizationModeWithInfoDictionaryObject:@"MGLIdeographsRasterizedLocally"];
 
-        XCTAssertEqual(option, MGLIdeographsRasterizedLocally, @"Glyphs rasterization mode should be `MGLIdeographsRasterizedLocally`.");
+        XCTAssertEqual(mode, MGLGlyphsRasterizationModeNoGlyphsRasterizedLocally, @"Glyphs rasterization mode should be `MGLIdeographsRasterizedLocally`.");
     }
 
     // `MGLGlyphsRasterizationMode` set to "MGLAllGlyphsRasterizedLocally".
     {
-        MGLGlyphsRasterizationMode option = [config glyphsRasterizationModeWithInfoDictionaryObject:@"MGLAllGlyphsRasterizedLocally"];
+        MGLGlyphsRasterizationMode mode = [config glyphsRasterizationModeWithInfoDictionaryObject:@"MGLAllGlyphsRasterizedLocally"];
 
-        XCTAssertEqual(option, MGLAllGlyphsRasterizedLocally, @"Glyphs rasterization mode should be `MGLAllGlyphsRasterizedLocally`.");
+        XCTAssertEqual(mode, MGLGlyphsRasterizationModeAllGlyphsRasterizedLocally, @"Glyphs rasterization mode should be `MGLAllGlyphsRasterizedLocally`.");
+    }
+}
+
+- (void)testGlyphsRasterizationOptions {
+    MGLRendererConfiguration *config = [[MGLRendererConfiguration alloc] init];
+
+    // `MGLIdeographicFontFamilyName` unset, MGLGlyphsRasterizationMode set to AllGlyphsRasterizedLocally.
+    {
+        mbgl::GlyphsRasterizationOptions options = [config glyphsRasterizationOptionsWithLocalFontFamilyName:nil rasterizationMode:MGLGlyphsRasterizationModeAllGlyphsRasterizedLocally];
+
+        XCTAssertEqual(options.fontFamily, mbgl::nullopt, @"Font family name should be `nullptr`");
+        XCTAssertEqual(options.rasterizationMode, mbgl::GlyphsRasterizationMode::NoGlyphsRasterizedLocally, @"Glyphs rasterization mode should be `NoGlyphsRasterizedLocally`");
+    }
+    
+    // `MGLIdeographicFontFamilyName` unset, MGLGlyphsRasterizationMode set to NoGlyphsRasterizedLocally.
+    {
+        mbgl::GlyphsRasterizationOptions options = [config glyphsRasterizationOptionsWithLocalFontFamilyName:nil rasterizationMode:MGLGlyphsRasterizationModeNoGlyphsRasterizedLocally];
+
+        XCTAssertEqual(options.fontFamily, mbgl::nullopt, @"Font family name should be `nullptr`");
+        XCTAssertEqual(options.rasterizationMode, mbgl::GlyphsRasterizationMode::NoGlyphsRasterizedLocally, @"Glyphs rasterization mode should be `NoGlyphsRasterizedLocally`");
+    }
+    
+    // `MGLIdeographicFontFamilyName` set to "Ping Fang", MGLGlyphsRasterizationMode set to IdeographsRasterizedLocally.
+    {
+        mbgl::GlyphsRasterizationOptions options = [config glyphsRasterizationOptionsWithLocalFontFamilyName:@"Ping Fang" rasterizationMode:MGLGlyphsRasterizationModeIdeographsRasterizedLocally];
+
+        XCTAssertEqual(options.fontFamily, std::string(@"Ping Fang".UTF8String), @"Font family name should be `Ping Fang`");
+        XCTAssertEqual(options.rasterizationMode, mbgl::GlyphsRasterizationMode::IdeographsRasterizedLocally, @"Glyphs rasterization mode should be `IdeographsRasterizedLocally`");
+    }
+    
+    // `MGLIdeographicFontFamilyName` set to "Ping Fang", MGLGlyphsRasterizationMode set to NoGlyphsRasterizedLocally.
+    {
+        mbgl::GlyphsRasterizationOptions options = [config glyphsRasterizationOptionsWithLocalFontFamilyName:@"Ping Fang" rasterizationMode:MGLGlyphsRasterizationModeNoGlyphsRasterizedLocally];
+
+        XCTAssertEqual(options.fontFamily, std::string(@"Ping Fang".UTF8String), @"Font family name should be `Ping Fang`");
+        XCTAssertEqual(options.rasterizationMode, mbgl::GlyphsRasterizationMode::NoGlyphsRasterizedLocally, @"Glyphs rasterization mode should be `NoGlyphsRasterizedLocally`");
+    }
+    
+    // `MGLIdeographicFontFamilyName` set to "Ping Fang", MGLGlyphsRasterizationMode set to AllGlyphsRasterizedLocally.
+    {
+        mbgl::GlyphsRasterizationOptions options = [config glyphsRasterizationOptionsWithLocalFontFamilyName:@"Ping Fang" rasterizationMode:MGLGlyphsRasterizationModeAllGlyphsRasterizedLocally];
+
+        XCTAssertEqual(options.fontFamily, std::string(@"Ping Fang".UTF8String), @"Font family name should be `Ping Fang`");
+        XCTAssertEqual(options.rasterizationMode, mbgl::GlyphsRasterizationMode::AllGlyphsRasterizedLocally, @"Glyphs rasterization mode should be `AllGlyphsRasterizedLocally`");
+    }
+    
+    // `MGLIdeographicFontFamilyName` set to "Ping Fang", MGLGlyphsRasterizationMode unset.
+    {
+        mbgl::GlyphsRasterizationOptions options = [config glyphsRasterizationOptionsWithLocalFontFamilyName:@"Ping Fang" rasterizationMode:MGLGlyphsRasterizationModeNone];
+
+        XCTAssertEqual(options.fontFamily, std::string(@"Ping Fang".UTF8String), @"Font family name should be `Ping Fang`");
+        XCTAssertEqual(options.rasterizationMode, mbgl::GlyphsRasterizationMode::NoGlyphsRasterizedLocally, @"Glyphs rasterization mode should be `NoGlyphsRasterizedLocally`");
     }
 }
 

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -192,10 +192,10 @@
 		35E79F201D41266300957B9E /* MGLStyleLayer_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 35E79F1F1D41266300957B9E /* MGLStyleLayer_Private.h */; };
 		35E79F211D41266300957B9E /* MGLStyleLayer_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 35E79F1F1D41266300957B9E /* MGLStyleLayer_Private.h */; };
 		3E6465D62065767A00685536 /* LimeGreenStyleLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E6465D42065767A00685536 /* LimeGreenStyleLayer.m */; };
-		3EA93369F61CF70AFA50465D /* MGLRendererConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EA931BC4F087E166D538F21 /* MGLRendererConfiguration.m */; };
+		3EA93369F61CF70AFA50465D /* MGLRendererConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3EA931BC4F087E166D538F21 /* MGLRendererConfiguration.mm */; };
 		3EA934623AD0000B7D99C3FB /* MGLRendererConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EA9337830C7738BF7F5493C /* MGLRendererConfiguration.h */; };
 		3EA9363147E77DD29FA06063 /* MGLRendererConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EA9337830C7738BF7F5493C /* MGLRendererConfiguration.h */; };
-		3EA9366247780E4F252652A8 /* MGLRendererConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EA931BC4F087E166D538F21 /* MGLRendererConfiguration.m */; };
+		3EA9366247780E4F252652A8 /* MGLRendererConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3EA931BC4F087E166D538F21 /* MGLRendererConfiguration.mm */; };
 		400533011DB0862B0069F638 /* NSArray+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 400532FF1DB0862B0069F638 /* NSArray+MGLAdditions.h */; };
 		400533021DB0862B0069F638 /* NSArray+MGLAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 400533001DB0862B0069F638 /* NSArray+MGLAdditions.mm */; };
 		400533031DB086490069F638 /* NSArray+MGLAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 400533001DB0862B0069F638 /* NSArray+MGLAdditions.mm */; };
@@ -249,6 +249,8 @@
 		55E2AD131E5B125400E8C587 /* MGLOfflineStorageTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 55E2AD121E5B125400E8C587 /* MGLOfflineStorageTests.mm */; };
 		632281DF1E6F855900D75A5D /* MBXEmbeddedMapViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 632281DE1E6F855900D75A5D /* MBXEmbeddedMapViewController.m */; };
 		6407D6701E0085FD00F6A9C3 /* MGLDocumentationExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6407D66F1E0085FD00F6A9C3 /* MGLDocumentationExampleTests.swift */; };
+		666F09472542D24800CEBB9D /* MGLRendererConfiguration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 666F09412542D1F200CEBB9D /* MGLRendererConfiguration_Private.h */; };
+		666F094D2542D24C00CEBB9D /* MGLRendererConfiguration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 666F09412542D1F200CEBB9D /* MGLRendererConfiguration_Private.h */; };
 		6F018BAE220031B8003E7269 /* UIView+MGLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6FAFA29B220023840088709E /* UIView+MGLAdditions.m */; };
 		6F018BAF220031BF003E7269 /* UIView+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FAFA29A220023840088709E /* UIView+MGLAdditions.h */; };
 		6F018BB0220031BF003E7269 /* UIView+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FAFA29A220023840088709E /* UIView+MGLAdditions.h */; };
@@ -438,7 +440,7 @@
 		CA8A310924ACE81B008CB6D8 /* mixed.json in Resources */ = {isa = PBXBuildFile; fileRef = CA8A310324ACE80B008CB6D8 /* mixed.json */; };
 		CA8A310A24ACE825008CB6D8 /* sideload_sat.db in Resources */ = {isa = PBXBuildFile; fileRef = CA8A310524ACE80B008CB6D8 /* sideload_sat.db */; };
 		CA8A310B24ACE82B008CB6D8 /* sideload_sat.db in Resources */ = {isa = PBXBuildFile; fileRef = CA8A310524ACE80B008CB6D8 /* sideload_sat.db */; };
-		CA8FBC0921A47BB100D1203C /* MGLRendererConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA8FBC0821A47BB100D1203C /* MGLRendererConfigurationTests.m */; };
+		CA8FBC0921A47BB100D1203C /* MGLRendererConfigurationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CA8FBC0821A47BB100D1203C /* MGLRendererConfigurationTests.mm */; };
 		CA94E5FB237D21030037AEA0 /* Mapbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA8847D21CBAF91600AB86E3 /* Mapbox.framework */; };
 		CA94E5FC237D21030037AEA0 /* Mapbox.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DA8847D21CBAF91600AB86E3 /* Mapbox.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CAA69DA5206DCD0E007279CD /* Mapbox.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DA4A26961CB6E795000B7809 /* Mapbox.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -934,7 +936,7 @@
 		35E79F1F1D41266300957B9E /* MGLStyleLayer_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLStyleLayer_Private.h; sourceTree = "<group>"; };
 		3E6465D42065767A00685536 /* LimeGreenStyleLayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LimeGreenStyleLayer.m; path = ../../darwin/app/LimeGreenStyleLayer.m; sourceTree = "<group>"; };
 		3E6465D52065767A00685536 /* LimeGreenStyleLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LimeGreenStyleLayer.h; path = ../../darwin/app/LimeGreenStyleLayer.h; sourceTree = "<group>"; };
-		3EA931BC4F087E166D538F21 /* MGLRendererConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLRendererConfiguration.m; sourceTree = "<group>"; };
+		3EA931BC4F087E166D538F21 /* MGLRendererConfiguration.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLRendererConfiguration.mm; sourceTree = "<group>"; };
 		3EA9337830C7738BF7F5493C /* MGLRendererConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLRendererConfiguration.h; sourceTree = "<group>"; };
 		400532FF1DB0862B0069F638 /* NSArray+MGLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+MGLAdditions.h"; sourceTree = "<group>"; };
 		400533001DB0862B0069F638 /* NSArray+MGLAdditions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "NSArray+MGLAdditions.mm"; sourceTree = "<group>"; };
@@ -976,6 +978,7 @@
 		632281DD1E6F855900D75A5D /* MBXEmbeddedMapViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBXEmbeddedMapViewController.h; sourceTree = "<group>"; };
 		632281DE1E6F855900D75A5D /* MBXEmbeddedMapViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MBXEmbeddedMapViewController.m; sourceTree = "<group>"; };
 		6407D66F1E0085FD00F6A9C3 /* MGLDocumentationExampleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MGLDocumentationExampleTests.swift; path = ../../darwin/test/MGLDocumentationExampleTests.swift; sourceTree = "<group>"; };
+		666F09412542D1F200CEBB9D /* MGLRendererConfiguration_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLRendererConfiguration_Private.h; sourceTree = "<group>"; };
 		6FA9341521EF372100AA9CA8 /* MBXOrnamentsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MBXOrnamentsViewController.m; sourceTree = "<group>"; };
 		6FA9341621EF372100AA9CA8 /* MBXOrnamentsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBXOrnamentsViewController.h; sourceTree = "<group>"; };
 		6FAFA29A220023840088709E /* UIView+MGLAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+MGLAdditions.h"; sourceTree = "<group>"; };
@@ -1103,7 +1106,7 @@
 		CA8A310324ACE80B008CB6D8 /* mixed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = mixed.json; sourceTree = "<group>"; };
 		CA8A310524ACE80B008CB6D8 /* sideload_sat.db */ = {isa = PBXFileReference; lastKnownFileType = file; path = sideload_sat.db; sourceTree = "<group>"; };
 		CA8A310724ACE80B008CB6D8 /* glyphs.pbf */ = {isa = PBXFileReference; lastKnownFileType = file; path = glyphs.pbf; sourceTree = "<group>"; };
-		CA8FBC0821A47BB100D1203C /* MGLRendererConfigurationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MGLRendererConfigurationTests.m; path = ../../darwin/test/MGLRendererConfigurationTests.m; sourceTree = "<group>"; };
+		CA8FBC0821A47BB100D1203C /* MGLRendererConfigurationTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLRendererConfigurationTests.mm; path = ../../darwin/test/MGLRendererConfigurationTests.mm; sourceTree = "<group>"; };
 		CA96299B23731199004F1330 /* MapboxMobileEvents.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MapboxMobileEvents.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CAAA65D72321BBA900F08A39 /* MGLTestAssertionHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MGLTestAssertionHandler.h; path = ../../darwin/test/MGLTestAssertionHandler.h; sourceTree = "<group>"; };
 		CAAA65D82321BBA900F08A39 /* MGLTestAssertionHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MGLTestAssertionHandler.m; path = ../../darwin/test/MGLTestAssertionHandler.m; sourceTree = "<group>"; };
@@ -1987,7 +1990,7 @@
 				DA2E885E1CC0382C00F24E7B /* MGLOfflineRegionTests.m */,
 				55E2AD121E5B125400E8C587 /* MGLOfflineStorageTests.mm */,
 				35B8E08B1D6C8B5100E768D2 /* MGLPredicateTests.mm */,
-				CA8FBC0821A47BB100D1203C /* MGLRendererConfigurationTests.m */,
+				CA8FBC0821A47BB100D1203C /* MGLRendererConfigurationTests.mm */,
 				CAD9D0A922A86D6F001B25EE /* MGLResourceTests.mm */,
 				DA2E88601CC0382C00F24E7B /* MGLStyleTests.mm */,
 				556660D71E1D085500E2C41B /* MGLVersionNumber.m */,
@@ -2057,7 +2060,8 @@
 				DA35D9BF240916290013ECB0 /* MGLReachability.h */,
 				DA35D9BE240916290013ECB0 /* MGLReachability.m */,
 				3EA9337830C7738BF7F5493C /* MGLRendererConfiguration.h */,
-				3EA931BC4F087E166D538F21 /* MGLRendererConfiguration.m */,
+				666F09412542D1F200CEBB9D /* MGLRendererConfiguration_Private.h */,
+				3EA931BC4F087E166D538F21 /* MGLRendererConfiguration.mm */,
 				92F2C3EC1F0E3C3A00268EC0 /* MGLRendererFrontend.h */,
 				DA8847EC1CBAFA5100AB86E3 /* MGLStyle.h */,
 				35E0CFE51D3E501500188327 /* MGLStyle_Private.h */,
@@ -2411,6 +2415,7 @@
 				DA8847F01CBAFA5100AB86E3 /* MGLAnnotation.h in Headers */,
 				400533011DB0862B0069F638 /* NSArray+MGLAdditions.h in Headers */,
 				96E6145922CC169000109F14 /* MGLCompassButton.h in Headers */,
+				666F09472542D24800CEBB9D /* MGLRendererConfiguration_Private.h in Headers */,
 				1F06668A1EC64F8E001C16D7 /* MGLLight.h in Headers */,
 				4049C29D1DB6CD6C00B3F799 /* MGLPointCollection.h in Headers */,
 				40CF6DBB1DAC3C6600A4D18B /* MGLShape_Private.h in Headers */,
@@ -2581,6 +2586,7 @@
 				96E516E52000560B00A02306 /* MGLOfflinePack_Private.h in Headers */,
 				DD9BE4F91EB263D20079A3AF /* UIViewController+MGLAdditions.h in Headers */,
 				9680274022653B84006BA4A1 /* MBXSKUToken.h in Headers */,
+				666F094D2542D24C00CEBB9D /* MGLRendererConfiguration_Private.h in Headers */,
 				DAF2571C201901E200367EF5 /* MGLHillshadeStyleLayer.h in Headers */,
 				74CB5EC4219B282500102936 /* MGLCircleStyleLayer_Private.h in Headers */,
 				DABFB8621CBE99E500D62B32 /* MGLOfflinePack.h in Headers */,
@@ -3206,7 +3212,7 @@
 				1F95931D1E6DE2E900D5B294 /* MGLNSDateAdditionsTests.mm in Sources */,
 				DA695426215B1E76002041A4 /* MGLMapCameraTests.m in Sources */,
 				96381C0222C6F3950053497D /* MGLMapViewPitchTests.m in Sources */,
-				CA8FBC0921A47BB100D1203C /* MGLRendererConfigurationTests.m in Sources */,
+				CA8FBC0921A47BB100D1203C /* MGLRendererConfigurationTests.mm in Sources */,
 				CAD9D0AA22A86D6F001B25EE /* MGLResourceTests.mm in Sources */,
 				DD58A4C61D822BD000E1F038 /* MGLExpressionTests.mm in Sources */,
 				3575798B1D502B0C000B822E /* MGLBackgroundStyleLayerTests.mm in Sources */,
@@ -3335,7 +3341,7 @@
 				DA8848271CBAFA6200AB86E3 /* MGLPolyline.mm in Sources */,
 				35CE61841D4165D9004F2359 /* UIColor+MGLAdditions.mm in Sources */,
 				1F716F1524FFEA6500C574BD /* MGLUserLocationAnnotationViewStyle.m in Sources */,
-				3EA93369F61CF70AFA50465D /* MGLRendererConfiguration.m in Sources */,
+				3EA93369F61CF70AFA50465D /* MGLRendererConfiguration.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3439,7 +3445,7 @@
 				35CE61851D4165D9004F2359 /* UIColor+MGLAdditions.mm in Sources */,
 				DAA4E4241CBB730400178DFB /* MGLPolyline.mm in Sources */,
 				1F716F1624FFEA6500C574BD /* MGLUserLocationAnnotationViewStyle.m in Sources */,
-				3EA9366247780E4F252652A8 /* MGLRendererConfiguration.m in Sources */,
+				3EA9366247780E4F252652A8 /* MGLRendererConfiguration.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -557,7 +557,21 @@ public:
     MGLRendererConfiguration *config = [MGLRendererConfiguration currentConfiguration];
 
     mbgl::optional<std::string> localFontFamilyName = config.localFontFamilyName ? mbgl::optional<std::string>(std::string(config.localFontFamilyName.UTF8String)) : mbgl::nullopt;
-    auto renderer = std::make_unique<mbgl::Renderer>(_mbglView->getRendererBackend(), config.scaleFactor, localFontFamilyName);
+    mbgl::GlyphsRasterizationOptions glyphsRasterizationOptions;
+    glyphsRasterizationOptions.fontFamily = localFontFamilyName;
+    switch (config.glyphsRasterizationMode) {
+        case MGLNoGlyphsRasterizedLocally:
+            glyphsRasterizationOptions.rasterizationMode = mbgl::GlyphsRasterizationMode::NoGlyphsRasterizedLocally;
+            break;
+        case MGLIdeographsRasterizedLocally:
+            glyphsRasterizationOptions.rasterizationMode = mbgl::GlyphsRasterizationMode::IdeographsRasterizedLocally;
+            break;
+        case MGLAllGlyphsRasterizedLocally:
+            glyphsRasterizationOptions.rasterizationMode = mbgl::GlyphsRasterizationMode::AllGlyphsRasterizedLocally;
+            break;
+    }
+
+    auto renderer = std::make_unique<mbgl::Renderer>(_mbglView->getRendererBackend(), config.scaleFactor, glyphsRasterizationOptions);
     BOOL enableCrossSourceCollisions = !config.perSourceCollisions;
     _rendererFrontend = std::make_unique<MGLRenderFrontend>(std::move(renderer), self, _mbglView->getRendererBackend());
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -37,7 +37,7 @@
 #import "MGLVectorTileSource_Private.h"
 #import "MGLFoundation_Private.h"
 #import "MGLRendererFrontend.h"
-#import "MGLRendererConfiguration.h"
+#import "MGLRendererConfiguration_Private.h"
 
 #import "NSBundle+MGLAdditions.h"
 #import "NSDate+MGLAdditions.h"
@@ -555,23 +555,7 @@ public:
 
     // setup mbgl map
     MGLRendererConfiguration *config = [MGLRendererConfiguration currentConfiguration];
-
-    mbgl::optional<std::string> localFontFamilyName = config.localFontFamilyName ? mbgl::optional<std::string>(std::string(config.localFontFamilyName.UTF8String)) : mbgl::nullopt;
-    mbgl::GlyphsRasterizationOptions glyphsRasterizationOptions;
-    glyphsRasterizationOptions.fontFamily = localFontFamilyName;
-    switch (config.glyphsRasterizationMode) {
-        case MGLNoGlyphsRasterizedLocally:
-            glyphsRasterizationOptions.rasterizationMode = mbgl::GlyphsRasterizationMode::NoGlyphsRasterizedLocally;
-            break;
-        case MGLIdeographsRasterizedLocally:
-            glyphsRasterizationOptions.rasterizationMode = mbgl::GlyphsRasterizationMode::IdeographsRasterizedLocally;
-            break;
-        case MGLAllGlyphsRasterizedLocally:
-            glyphsRasterizationOptions.rasterizationMode = mbgl::GlyphsRasterizationMode::AllGlyphsRasterizedLocally;
-            break;
-    }
-
-    auto renderer = std::make_unique<mbgl::Renderer>(_mbglView->getRendererBackend(), config.scaleFactor, glyphsRasterizationOptions);
+    auto renderer = std::make_unique<mbgl::Renderer>(_mbglView->getRendererBackend(), config.scaleFactor, config.glyphsRasterizationOptions);
     BOOL enableCrossSourceCollisions = !config.perSourceCollisions;
     _rendererFrontend = std::make_unique<MGLRenderFrontend>(std::move(renderer), self, _mbglView->getRendererBackend());
 


### PR DESCRIPTION
Add `MGLGlyphsRasterizationMode` indicates how the map view load glyphs.