### PR TITLE
Updates podspecs' events dependency

### DIFF
--- a/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
@@ -29,6 +29,6 @@ Pod::Spec.new do |m|
 
   m.preserve_path = '**/*.bcsymbolmap'
 
-  m.dependency "MapboxMobileEvents", "~> 0.10.4"
+  m.dependency "MapboxMobileEvents", "~> 0.10"
 
 end

--- a/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-snapshot-dynamic.podspec
@@ -29,6 +29,6 @@ Pod::Spec.new do |m|
 
   m.preserve_path = '**/*.bcsymbolmap'
 
-  m.dependency "MapboxMobileEvents", "~> 0.10"
+  m.dependency "MapboxMobileEvents", "~> 0.10.5"
 
 end

--- a/platform/ios/Mapbox-iOS-SDK-stripped.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-stripped.podspec
@@ -29,6 +29,6 @@ Pod::Spec.new do |m|
 
   m.preserve_path = '**/*.bcsymbolmap'
 
-  m.dependency "MapboxMobileEvents", "~> 0.10.4"
+  m.dependency "MapboxMobileEvents", "~> 0.10"
 
 end

--- a/platform/ios/Mapbox-iOS-SDK-stripped.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-stripped.podspec
@@ -29,6 +29,6 @@ Pod::Spec.new do |m|
 
   m.preserve_path = '**/*.bcsymbolmap'
 
-  m.dependency "MapboxMobileEvents", "~> 0.10"
+  m.dependency "MapboxMobileEvents", "~> 0.10.5"
 
 end

--- a/platform/ios/Mapbox-iOS-SDK.podspec
+++ b/platform/ios/Mapbox-iOS-SDK.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |m|
 
   m.preserve_path = '**/*.bcsymbolmap'
 
-  m.dependency "MapboxMobileEvents", "~> 0.10.4"
+  m.dependency "MapboxMobileEvents", "~> 0.10"
 
   m.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64 arm64e' }
  

--- a/platform/ios/Mapbox-iOS-SDK.podspec
+++ b/platform/ios/Mapbox-iOS-SDK.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |m|
 
   m.preserve_path = '**/*.bcsymbolmap'
 
-  m.dependency "MapboxMobileEvents", "~> 0.10"
+  m.dependency "MapboxMobileEvents", "~> 0.10.5"
 
   m.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64 arm64e' }
  


### PR DESCRIPTION
This PR updates the events-ios dependency to 0.10.5.

See https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#version-requirement, especially the section about `0.x.y` releases. i.e. in future, we may need to change CocoaPods' behavior to `~> 1.0` to match the behavior of Carthage (`~> 1.0.0`).