### PR TITLE
Distinguish between internal and external Carthage usage

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps-gl-core/mapbox-ios-sdk-gl-core-static.json" == 5.2.1
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps/mapbox-ios-sdk-dynamic.json" == 6.3.0
 github "mapbox/mapbox-events-ios" ~> 0.10.5

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,0 +1,1 @@
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps-gl-core/mapbox-ios-sdk-gl-core-static.json" == 5.2.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,3 @@
 binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps-gl-core/mapbox-ios-sdk-gl-core-static.json" "5.2.1"
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps/mapbox-ios-sdk-dynamic.json" "6.3.0"
 github "mapbox/mapbox-events-ios" "v0.10.5"


### PR DESCRIPTION
A new Cartfile.private lists the dependencies necessary to build the map SDK from source, while the main Cartfile now obtains the prebuilt map SDK itself along with MapboxMobileEvents. A contributor will get both sets of dependencies when bootstrapping, but they can ignore the prebuilt SDK binary. Meanwhile, a developer can now point their Cartfile to this repository to install the map SDK:

```properties
github "mapbox/mapbox-gl-native-ios" ~> 6.3
```

When releasing the map SDK, the version specification in Cartfile needs to be updated to exactly match the version being tagged – prereleases and final releases alike.

With this change, developers no longer need to keep track of compatible MapboxMobileEvents themselves, giving us some room to increase the minimum supported MME version when necessary. Unfortunately, developers will end up with a full clone of this repository. Deleting old tags carried over from the mapbox-gl-native repository would help a bit: #109. If cloning this repository makes the `github` specification impractical, then we should close this PR and copy the Cartfile to a separate repository that hosts only the Cartfile.

Wherever we put the Cartfile, we can expect the Package.swift for Swift Package Manager (mapbox/mapbox-gl-native#15241 #546) to sit alongside it.

<!-- <changelog>Simplified the Carthage-based installation instructions. Now your Cartfile only needs to list `github "mapbox/mapbox-gl-native-ios" ~> 6.3`. You can remove the `binary` specification and explicit dependency on `mapbox/mapbox-events-ios`.</changelog> -->

Fixes #143.

/cc @mapbox/maps-ios @mapbox/navigation-ios @frederoni