### PR TITLE
Refine Apple Silicon / CocoaPods workaround

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## main
+
+### 🐞 Bug fixes
+
+* Fixed a CocoaPods warning when integrating this SDK and the Mapbox Navigation SDK for iOS into the same application. ([#549](https://github.com/mapbox/mapbox-gl-native-ios/pull/549))
+
 ## 6.3.0 - November 10, 2020
 
 This version does not support Apple Silicon Macs (arm64).

--- a/platform/ios/Mapbox-iOS-SDK.podspec
+++ b/platform/ios/Mapbox-iOS-SDK.podspec
@@ -31,8 +31,13 @@ Pod::Spec.new do |m|
 
   m.dependency "MapboxMobileEvents", "~> 0.10.5"
 
-  m.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64 arm64e' }
- 
-  m.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64 arm64e' }
+  m.user_target_xcconfig = {
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => '$(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))',
+    'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200' => 'arm64 arm64e armv7 armv7s armv6 armv8'
+  }
+  m.pod_target_xcconfig = {
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => '$(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))',
+    'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200' => 'arm64 arm64e armv7 armv7s armv6 armv8'
+  }
 
 end


### PR DESCRIPTION
The CocoaPods podspec now excludes 64-bit ARM architectures less aggressively with build settings that match the iOS navigation SDK. The new build setting takes into account the native architecture of the build machine, the Xcode major version, and the target environment.

I pushed a clone of this podspec to a throwaway pod to CocoaPods trunk in CocoaPods/Specs@a1b0a72547bc6cb91a6e9fa21826a84b0ce91f27. I also pushed a clone of the navigation SDK podspec that depends on this throwaway pod in CocoaPods/Specs@c641e3076080da07a0007f7b716169e4d08ce140.

<!-- `<changelog>Fixed a CocoaPods warning when integrating this SDK and the Mapbox Navigation SDK for iOS into the same application.</changelog>` -->

Fixes mapbox/mapbox-navigation-ios#2739.

/cc @mapbox/navigation-ios @julianrex @ZiZasaurus @frederoni