### PR TITLE
Fix potential crash in `+[NSOrthography mgl_dominantScriptForMapboxStreetsLanguage:]`

### DIFF
--- a/platform/ios/src/NSOrthography+MGLAdditions.m
+++ b/platform/ios/src/NSOrthography+MGLAdditions.m
@@ -5,9 +5,10 @@
 + (NSString *)mgl_dominantScriptForMapboxStreetsLanguage:(NSString *)language {
     if (@available(iOS 11.0, *)) {
         NSLocale *locale = [NSLocale localeWithLocaleIdentifier:language];
-        NSOrthography *orthography = [NSOrthography defaultOrthographyForLanguage:locale.localeIdentifier];
-
-        return orthography.dominantScript;
+        if (locale.localeIdentifier != nil) {
+            NSOrthography *orthography = [NSOrthography defaultOrthographyForLanguage:locale.localeIdentifier];
+            return orthography.dominantScript;
+        }
     }
 
     // Manually map Mapbox Streets languages to ISO 15924 script codes.


### PR DESCRIPTION
**Description:**
`+[NSOrthography defaultOrthographyForLanguage:]` will crash when a `nil` language is passed. 

<img width="1046" alt="Screen Shot 2021-06-08 at 3 08 43 PM" src="https://user-images.githubusercontent.com/5728070/121252178-54862500-c86d-11eb-9a89-543ec271d512.png">

This could previously happen in `+[NSOrthography mgl_dominantScriptForMapboxStreetsLanguage:]`. Calling location of this Mapbox method:

https://github.com/mapbox/mapbox-gl-native-ios/blob/ddf8e35970d1a8a46171bd798bcfa8f22d2760e0/platform/ios/src/MGLMapAccessibilityElement.mm#L61-L68

The result is passed to :point_down: which can handle a `nil` `script` param:

https://github.com/mapbox/mapbox-gl-native-ios/blob/ddf8e35970d1a8a46171bd798bcfa8f22d2760e0/platform/darwin/src/NSString%2BMGLAdditions.m#L43

Might fix https://github.com/mapbox/mapbox-gl-native-ios/issues/562.

`<changelog>Fixed a bug where `mgl_dominantScriptForMapboxStreetsLanguage` would crash with a `nil` param.</changelog>`
