### PR TITLE
Invalidate unused offline packs before dealloc

### DIFF
--- a/platform/darwin/src/MGLOfflinePack.mm
+++ b/platform/darwin/src/MGLOfflinePack.mm
@@ -147,11 +147,16 @@ private:
     MGLOfflineStorage *sharedOfflineStorage = [MGLOfflineStorage sharedOfflineStorage];
     __weak MGLOfflinePack *weakSelf = self;
     [sharedOfflineStorage getPacksWithCompletionHandler:^(NSArray<MGLOfflinePack *> *packs, __unused NSError * _Nullable error) {
+        MGLOfflinePack *strongSelf = weakSelf;
         for (MGLOfflinePack *pack in packs) {
             if (pack.mbglOfflineRegion->getID() == regionID) {
-                weakSelf.mbglOfflineRegion = pack.mbglOfflineRegion;
-                break;
+                if (strongSelf.mbglOfflineRegion) {
+                    strongSelf->_mbglDatabaseFileSource->setOfflineRegionObserver(*strongSelf.mbglOfflineRegion, nullptr);
+                }
+                strongSelf.mbglOfflineRegion = pack.mbglOfflineRegion;
+                strongSelf->_mbglDatabaseFileSource->setOfflineRegionObserver(*strongSelf.mbglOfflineRegion, std::make_unique<MBGLOfflineDownloadObserver>(strongSelf));
             }
+            [pack invalidate];
         }
         completion(error);
     }];

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 ### 🐞 Bug fixes
 
 * Fixed a CocoaPods warning when integrating this SDK and the Mapbox Navigation SDK for iOS into the same application. ([#549](https://github.com/mapbox/mapbox-gl-native-ios/pull/549))
+* Fixed an issue where offline packs were not invalidated before being deallocated, resulting in a crash. ([#620](https://github.com/mapbox/mapbox-gl-native-ios/pull/620))
 
 ## 6.3.0 - November 10, 2020
 


### PR DESCRIPTION
iOS 15 revealed a logic error in which certain offline packs were not being invalidated before being deallocated.