### PR TITLE
Remove pausing of file sources in background

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## main
+
+* Fixed watchdog termination caused by pausing file sources when entering the background. ([#639](https://github.com/mapbox/mapbox-gl-native-ios/pull/639))
+
 ## 6.4.0 - September 27, 2021
 
 This version does not support Apple Silicon Macs (arm64).


### PR DESCRIPTION
This behavior was introduced in response to a crash in 2016, but has led to watchdog terminations when apps enter the background. Subsequent refactoring to the file source implementations makes this behavior unnecessary. Equivalent behavior was also removed from Maps SDK v10 (mapbox-maps-ios).