### PR TITLE
Adding extra configurability to MGLUserLocationAnnotationViewStyle

### DIFF
--- a/platform/ios/src/MGLFaux3DUserLocationAnnotationView.mm
+++ b/platform/ios/src/MGLFaux3DUserLocationAnnotationView.mm
@@ -72,8 +72,6 @@ const CGFloat MGLUserLocationApproximateZoomThreshold = 7.0;
         }
         
     }
-
-    
 }
 
 - (void)drawPreciseLocationPuck {
@@ -92,6 +90,8 @@ const CGFloat MGLUserLocationApproximateZoomThreshold = 7.0;
 {
     UIColor *puckArrowFillColor = tintColor;
     UIColor *puckArrowStrokeColor = tintColor;
+    UIColor *puckBorderBackgroundColor = UIColor.whiteColor;
+    UIColor *puckArrowBackgroundColor = UIColor.whiteColor;
     
     UIColor *approximateFillColor = tintColor;
     
@@ -104,6 +104,7 @@ const CGFloat MGLUserLocationApproximateZoomThreshold = 7.0;
         MGLUserLocationAnnotationViewStyle *style = [self.mapView.delegate mapViewStyleForDefaultUserLocationAnnotationView:self.mapView];
         
         puckArrowFillColor = style.puckArrowFillColor ? style.puckArrowFillColor : puckArrowFillColor;
+        puckArrowBackgroundColor = style.puckArrowBackgroundColor ? style.puckArrowBackgroundColor : puckArrowBackgroundColor;
         
         if (@available(iOS 14, *)) {
             approximateFillColor = style.approximateHaloFillColor ? style.approximateHaloFillColor : approximateFillColor;
@@ -111,12 +112,14 @@ const CGFloat MGLUserLocationApproximateZoomThreshold = 7.0;
         
         haloFillColor = style.haloFillColor ? style.haloFillColor : haloFillColor;
         dotFillColor = style.puckFillColor ? style.puckFillColor : dotFillColor;
+        puckBorderBackgroundColor = style.puckBorderBackgroundColor ? style.puckBorderBackgroundColor : puckBorderBackgroundColor;
         headingFillColor = style.puckFillColor ? style.puckFillColor : headingFillColor;
     }
     
     if (_puckModeActivated)
     {
         _puckArrow.fillColor = [puckArrowFillColor CGColor];
+        _puckArrow.backgroundColor = [puckArrowBackgroundColor CGColor];
         _puckArrow.strokeColor = [puckArrowStrokeColor CGColor];
     }
     else if (_approximateModeActivated)
@@ -128,6 +131,7 @@ const CGFloat MGLUserLocationApproximateZoomThreshold = 7.0;
         _accuracyRingLayer.backgroundColor = [accuracyFillColor CGColor];
         _haloLayer.backgroundColor = [haloFillColor CGColor];
         _dotLayer.backgroundColor = [dotFillColor CGColor];
+        _dotBorderLayer.backgroundColor = [puckBorderBackgroundColor CGColor];
         [_headingIndicatorLayer updateTintColor:[headingFillColor CGColor]];
     }
     
@@ -206,14 +210,17 @@ const CGFloat MGLUserLocationApproximateZoomThreshold = 7.0;
     }
     
     UIColor *arrowColor = self.mapView.tintColor;
+    UIColor *puckArrowBackgroundColor = UIColor.whiteColor;
+    
     UIColor *puckShadowColor = UIColor.blackColor;
     CGFloat shadowOpacity = 0.25;
 
-    
     if ([self.mapView.delegate respondsToSelector:@selector(mapViewStyleForDefaultUserLocationAnnotationView:)]) {
         MGLUserLocationAnnotationViewStyle *style = [self.mapView.delegate mapViewStyleForDefaultUserLocationAnnotationView:self.mapView];
         arrowColor = style.puckArrowFillColor ? style.puckArrowFillColor : arrowColor;
         puckShadowColor = style.puckShadowColor ? style.puckShadowColor : puckShadowColor;
+        puckArrowBackgroundColor = style.puckArrowBackgroundColor ? style.puckArrowBackgroundColor : puckArrowBackgroundColor;
+        
         shadowOpacity = style.puckShadowOpacity;
     }
 
@@ -222,7 +229,7 @@ const CGFloat MGLUserLocationApproximateZoomThreshold = 7.0;
     if ( ! _puckDot)
     {
         _puckDot = [self circleLayerWithSize:MGLUserLocationAnnotationPuckSize];
-        _puckDot.backgroundColor = [[UIColor whiteColor] CGColor];
+        _puckDot.backgroundColor = [puckArrowBackgroundColor CGColor];
         _puckDot.shadowColor = [puckShadowColor CGColor];
         _puckDot.shadowOpacity = shadowOpacity;
         _puckDot.shadowPath = [[UIBezierPath bezierPathWithOvalInRect:_puckDot.bounds] CGPath];
@@ -302,6 +309,7 @@ const CGFloat MGLUserLocationApproximateZoomThreshold = 7.0;
     UIColor *haloColor = self.mapView.tintColor;
     UIColor *puckBackgroundColor = self.mapView.tintColor;
     UIColor *puckShadowColor = UIColor.blackColor;
+    UIColor *puckBorderBackgroundColor = UIColor.whiteColor;
     CGFloat shadowOpacity = 0.25;
 
     
@@ -310,6 +318,7 @@ const CGFloat MGLUserLocationApproximateZoomThreshold = 7.0;
         haloColor = style.haloFillColor ? style.haloFillColor : haloColor;
         puckBackgroundColor = style.puckFillColor ? style.puckFillColor : puckBackgroundColor;
         puckShadowColor = style.puckShadowColor ? style.puckShadowColor : puckShadowColor;
+        puckBorderBackgroundColor = style.puckBorderBackgroundColor ? style.puckBorderBackgroundColor : puckBorderBackgroundColor;
         shadowOpacity = style.puckShadowOpacity;
     }
 
@@ -467,7 +476,7 @@ const CGFloat MGLUserLocationApproximateZoomThreshold = 7.0;
     if ( ! _dotBorderLayer)
     {
         _dotBorderLayer = [self circleLayerWithSize:MGLUserLocationAnnotationDotSize];
-        _dotBorderLayer.backgroundColor = [[UIColor whiteColor] CGColor];
+        _dotBorderLayer.backgroundColor = [puckBorderBackgroundColor CGColor];
         _dotBorderLayer.shadowColor = [puckShadowColor CGColor];
         _dotBorderLayer.shadowOpacity = shadowOpacity;
         _dotBorderLayer.shadowPath = [[UIBezierPath bezierPathWithOvalInRect:_dotBorderLayer.bounds] CGPath];

--- a/platform/ios/src/MGLUserLocationAnnotationViewStyle.h
+++ b/platform/ios/src/MGLUserLocationAnnotationViewStyle.h
@@ -11,9 +11,13 @@ MGL_EXPORT
 @interface MGLUserLocationAnnotationViewStyle : NSObject
 
 /**
- The fill color for the puck view.
+ The fill color for the dot puck view.
  */
 @property (nonatomic) UIColor *puckFillColor;
+/**
+ The fill color for the background for the dot puck border.
+ */
+@property (nonatomic) UIColor *puckBorderBackgroundColor;
 /**
  The shadow color for the puck view.
  */
@@ -29,7 +33,11 @@ MGL_EXPORT
  */
 @property (nonatomic) UIColor *puckArrowFillColor;
 /**
- The fill color for the puck view.
+ The fill color for the background arrow puck.
+ */
+@property (nonatomic) UIColor *puckArrowBackgroundColor;
+/**
+ The halo fill color for the puck view.
  */
 @property (nonatomic) UIColor *haloFillColor;
 /**


### PR DESCRIPTION
Based on https://github.com/mapbox/mapbox-gl-native-ios/pull/403

Previously there was no way to change the background of the arrow puck view nor the border of the dot view.

So I'm exposing this configurability.

Ex
<img width="300" alt="SS1" src="https://user-images.githubusercontent.com/43767350/160921621-c3f1099d-cba8-4309-bc4d-a18ca9084315.png">

<img width="300" alt="SS1" src="https://user-images.githubusercontent.com/43767350/160921626-4176963e-d01a-4796-8a1b-84c5434813de.png">

